### PR TITLE
Migrate from taglibv1 to taglibv2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # define minimum cmake version
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.11)
 
 project( Guayadeque )
 
@@ -38,21 +38,17 @@ PKG_CHECK_MODULES( GSTREAMER_TAG REQUIRED gstreamer-tag-1.0 )
 PKG_CHECK_MODULES( SQLITE3 REQUIRED sqlite3 )
 PKG_CHECK_MODULES( LIBCURL REQUIRED libcurl )
 
-PKG_CHECK_MODULES( LIBTAG taglib>=1.6.4)
-IF( NOT LIBTAG_FOUND )
-        PKG_CHECK_MODULES( LIBTAG taglib>=1.6.1)
-        IF( NOT LIBTAG_FOUND )
-                PKG_CHECK_MODULES( LIBTAG taglib>=1.6 )
-                IF( NOT LIBTAG_FOUND )
-                        MESSAGE( FATAL_ERROR "taglib 1.6 not found!" )
-                ENDIF( NOT LIBTAG_FOUND )
-        ELSE( NOT LIBTAG_FOUND )
+PKG_CHECK_MODULES(LIBTAG taglib>=2.0)
+IF(NOT LIBTAG_FOUND)
+        MESSAGE(FATAL_ERROR "taglib 2.0 not found!")
+ELSE(NOT LIBTAG_FOUND)
+        IF(LIBTAG_VERSION LESS 3.0)
                 ADD_DEFINITIONS(-DTAGLIB_WITH_MP4_COVERS=1)
-        ENDIF( NOT LIBTAG_FOUND )
-ELSE( NOT LIBTAG_FOUND )
-        ADD_DEFINITIONS(-DTAGLIB_WITH_MP4_COVERS=1)
-        ADD_DEFINITIONS(-DTAGLIB_WITH_APE_SUPPORT=1)
-ENDIF( NOT LIBTAG_FOUND )
+                ADD_DEFINITIONS(-DTAGLIB_WITH_APE_SUPPORT=1)
+        ELSE(LIBTAG_VERSION LESS 3.0)
+                MESSAGE(FATAL_ERROR "taglib version must be less than 3.0!")
+        ENDIF(LIBTAG_VERSION LESS 3.0)
+ENDIF(NOT LIBTAG_FOUND)
 
 PKG_CHECK_MODULES( LIBDBUS REQUIRED dbus-1 )
 

--- a/po/guayadeque.pot
+++ b/po/guayadeque.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-03-18 13:16+0000\n"
+"POT-Creation-Date: 2024-03-27 01:07-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,102 +17,20 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: copyto/CopyTo.cpp:887
-#, c-format
-msgid ""
-"Copied %u files (%s)\n"
-"in %s seconds"
+#: ui/itemlistbox/ItemListBox.cpp:67 ui/preferences/Preferences.cpp:1763
+#: ui/preferences/Preferences.cpp:1858 ui/player/PlayerFilters.cpp:109
+#: ui/mediaviewer/library/AlListBox.cpp:490
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1700
+#: info/smartmode/SmartMode.cpp:397
+msgid "All"
 msgstr ""
 
-#: copyto/CopyTo.cpp:892
-msgid "Finished copying files"
+#: ui/itemlistbox/ListView.cpp:1478
+msgid "Select Columns"
 msgstr ""
 
-#: copyto/Transcode.cpp:300
-msgid "Keep Format"
-msgstr ""
-
-#: copyto/Transcode.cpp:323
-msgid "Keep Quality"
-msgstr ""
-
-#: copyto/Transcode.cpp:324 ui/preferences/Preferences.cpp:1176
-msgid "Very High"
-msgstr ""
-
-#: copyto/Transcode.cpp:325 ui/preferences/Preferences.cpp:1177
-msgid "High"
-msgstr ""
-
-#: copyto/Transcode.cpp:326
-msgid "Very Good"
-msgstr ""
-
-#: copyto/Transcode.cpp:327
-msgid "Good"
-msgstr ""
-
-#: copyto/Transcode.cpp:328 ui/preferences/Preferences.cpp:1178
-msgid "Normal"
-msgstr ""
-
-#: copyto/Transcode.cpp:329 ui/preferences/Preferences.cpp:1179
-msgid "Low"
-msgstr ""
-
-#: copyto/Transcode.cpp:330 ui/preferences/Preferences.cpp:1180
-msgid "Very Low"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:59
-msgid "Cover Editor"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:78 ui/lastfmpanel/LastFMPanel.cpp:1726
-#: ui/lyrics/LyricsPanel.cpp:114 ui/trackedit/TrackEdit.cpp:164
-#: ui/trackedit/TrackEdit.cpp:389 ui/trackedit/TrackEdit.cpp:430
-#: ui/trackedit/TrackEdit.cpp:489
-msgid "Artist:"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:85 ui/trackedit/TrackEdit.cpp:188
-#: ui/trackedit/TrackEdit.cpp:455 ui/trackedit/TrackEdit.cpp:511
-msgid "Album:"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:92
-msgid "From:"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:113 ui/cover/SelCoverFile.cpp:72
-msgid "Embed into tracks"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:581 ui/cover/SelCoverFile.cpp:122
-msgid "Select the cover filename"
-msgstr ""
-
-#: ui/cover/CoverEdit.cpp:608
-msgid "Cover Url"
-msgstr ""
-
-#: ui/cover/SelCoverFile.cpp:34
-msgid "Select Cover File"
-msgstr ""
-
-#: ui/cover/SelCoverFile.cpp:44 ui/mediaviewer/MediaViewer.cpp:1476
-msgid ""
-"Could not find the Album in the songs library.\n"
-"You should update the library."
-msgstr ""
-
-#: ui/cover/SelCoverFile.cpp:45 ui/mediaviewer/MediaViewer.cpp:1477
-#: ui/filebrowser/FileBrowser.cpp:578
-msgid "Error"
-msgstr ""
-
-#: ui/cover/SelCoverFile.cpp:60
-msgid "Cover:"
+#: ui/itemlistbox/ListView.cpp:1490
+msgid " Columns "
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:445 ui/lastfmpanel/LastFMPanel.cpp:686
@@ -126,25 +44,25 @@ msgstr ""
 #: ui/lastfmpanel/LastFMPanel.cpp:562 ui/lastfmpanel/LastFMPanel.cpp:833
 #: ui/lastfmpanel/LastFMPanel.cpp:1033 ui/lastfmpanel/LastFMPanel.cpp:1239
 #: ui/lastfmpanel/LastFMPanel.cpp:1456 ui/lastfmpanel/LastFMPanel.cpp:3232
-#: ui/radios/RadioPanel.cpp:425 ui/podcasts/PodcastsPanel.cpp:2069
+#: ui/radios/RadioPanel.cpp:417 ui/podcasts/PodcastsPanel.cpp:2051
+#: ui/taskbar/TaskBar.cpp:116 ui/MainFrame.cpp:1526
+#: ui/filebrowser/FileBrowser.cpp:344 ui/filebrowser/FileBrowser.cpp:1123
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:646
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:227
+#: ui/mediaviewer/treeview/TreePanel.cpp:389
+#: ui/mediaviewer/library/PcListBox.cpp:113
+#: ui/mediaviewer/library/TaListBox.cpp:126
+#: ui/mediaviewer/library/GeListBox.cpp:95
+#: ui/mediaviewer/library/RaListBox.cpp:145
+#: ui/mediaviewer/library/CoListBox.cpp:106
+#: ui/mediaviewer/library/AlListBox.cpp:266
+#: ui/mediaviewer/library/ArListBox.cpp:150
+#: ui/mediaviewer/library/YeListBox.cpp:106
+#: ui/mediaviewer/library/AAListBox.cpp:147
+#: ui/mediaviewer/library/SoListBox.cpp:523
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:341
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1935
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2070
-#: ui/mediaviewer/treeview/TreePanel.cpp:393
-#: ui/mediaviewer/library/CoListBox.cpp:106
-#: ui/mediaviewer/library/ArListBox.cpp:151
-#: ui/mediaviewer/library/GeListBox.cpp:95
-#: ui/mediaviewer/library/SoListBox.cpp:526
-#: ui/mediaviewer/library/AlListBox.cpp:267
-#: ui/mediaviewer/library/RaListBox.cpp:146
-#: ui/mediaviewer/library/TaListBox.cpp:126
-#: ui/mediaviewer/library/AAListBox.cpp:148
-#: ui/mediaviewer/library/YeListBox.cpp:106
-#: ui/mediaviewer/library/PcListBox.cpp:114
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:227
-#: ui/filebrowser/FileBrowser.cpp:344 ui/filebrowser/FileBrowser.cpp:1123
-#: ui/taskbar/TaskBar.cpp:116 ui/MainFrame.cpp:1526 misc/Accelerators.cpp:126
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2070 misc/Accelerators.cpp:126
 msgid "Play"
 msgstr ""
 
@@ -157,25 +75,24 @@ msgstr ""
 #: ui/lastfmpanel/LastFMPanel.cpp:566 ui/lastfmpanel/LastFMPanel.cpp:837
 #: ui/lastfmpanel/LastFMPanel.cpp:1037 ui/lastfmpanel/LastFMPanel.cpp:1243
 #: ui/lastfmpanel/LastFMPanel.cpp:1460 ui/lastfmpanel/LastFMPanel.cpp:3236
-#: ui/radios/RadioPanel.cpp:431 ui/podcasts/PodcastsPanel.cpp:2075
+#: ui/radios/RadioPanel.cpp:423 ui/podcasts/PodcastsPanel.cpp:2057
+#: ui/filebrowser/FileBrowser.cpp:350 ui/filebrowser/FileBrowser.cpp:1129
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:652
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:232
+#: ui/mediaviewer/treeview/TreePanel.cpp:394
+#: ui/mediaviewer/library/PcListBox.cpp:120
+#: ui/mediaviewer/library/TaListBox.cpp:133
+#: ui/mediaviewer/library/GeListBox.cpp:102
+#: ui/mediaviewer/library/RaListBox.cpp:152
+#: ui/mediaviewer/library/CoListBox.cpp:113
+#: ui/mediaviewer/library/AlListBox.cpp:272
+#: ui/mediaviewer/library/ArListBox.cpp:157
+#: ui/mediaviewer/library/YeListBox.cpp:113
+#: ui/mediaviewer/library/AAListBox.cpp:154
+#: ui/mediaviewer/library/SoListBox.cpp:530
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:345
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1939
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2074
-#: ui/mediaviewer/treeview/TreePanel.cpp:398
-#: ui/mediaviewer/library/CoListBox.cpp:113
-#: ui/mediaviewer/library/ArListBox.cpp:158
-#: ui/mediaviewer/library/GeListBox.cpp:102
-#: ui/mediaviewer/library/SoListBox.cpp:533
-#: ui/mediaviewer/library/AlListBox.cpp:273
-#: ui/mediaviewer/library/RaListBox.cpp:153
-#: ui/mediaviewer/library/TaListBox.cpp:133
-#: ui/mediaviewer/library/AAListBox.cpp:155
-#: ui/mediaviewer/library/YeListBox.cpp:113
-#: ui/mediaviewer/library/PcListBox.cpp:121
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:232
-#: ui/filebrowser/FileBrowser.cpp:350 ui/filebrowser/FileBrowser.cpp:1129
-#: misc/Accelerators.cpp:118
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2074 misc/Accelerators.cpp:118
 msgid "Enqueue"
 msgstr ""
 
@@ -188,162 +105,162 @@ msgstr ""
 #: ui/lastfmpanel/LastFMPanel.cpp:573 ui/lastfmpanel/LastFMPanel.cpp:844
 #: ui/lastfmpanel/LastFMPanel.cpp:1044 ui/lastfmpanel/LastFMPanel.cpp:1250
 #: ui/lastfmpanel/LastFMPanel.cpp:1467 ui/lastfmpanel/LastFMPanel.cpp:3243
-#: ui/radios/RadioPanel.cpp:439 ui/podcasts/PodcastsPanel.cpp:2083
+#: ui/radios/RadioPanel.cpp:431 ui/podcasts/PodcastsPanel.cpp:2065
+#: ui/filebrowser/FileBrowser.cpp:358 ui/filebrowser/FileBrowser.cpp:1137
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:660
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:240
+#: ui/mediaviewer/treeview/TreePanel.cpp:402
+#: ui/mediaviewer/library/PcListBox.cpp:129
+#: ui/mediaviewer/library/TaListBox.cpp:142
+#: ui/mediaviewer/library/GeListBox.cpp:111
+#: ui/mediaviewer/library/RaListBox.cpp:161
+#: ui/mediaviewer/library/CoListBox.cpp:122
+#: ui/mediaviewer/library/AlListBox.cpp:280
+#: ui/mediaviewer/library/ArListBox.cpp:166
+#: ui/mediaviewer/library/YeListBox.cpp:122
+#: ui/mediaviewer/library/AAListBox.cpp:163
+#: ui/mediaviewer/library/SoListBox.cpp:539
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:352
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1946
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2081
-#: ui/mediaviewer/treeview/TreePanel.cpp:406
-#: ui/mediaviewer/library/CoListBox.cpp:122
-#: ui/mediaviewer/library/ArListBox.cpp:167
-#: ui/mediaviewer/library/GeListBox.cpp:111
-#: ui/mediaviewer/library/SoListBox.cpp:542
-#: ui/mediaviewer/library/AlListBox.cpp:281
-#: ui/mediaviewer/library/RaListBox.cpp:162
-#: ui/mediaviewer/library/TaListBox.cpp:142
-#: ui/mediaviewer/library/AAListBox.cpp:164
-#: ui/mediaviewer/library/YeListBox.cpp:122
-#: ui/mediaviewer/library/PcListBox.cpp:130
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:240
-#: ui/filebrowser/FileBrowser.cpp:358 ui/filebrowser/FileBrowser.cpp:1137
 msgid "Current Track"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:574 ui/lastfmpanel/LastFMPanel.cpp:845
 #: ui/lastfmpanel/LastFMPanel.cpp:1045 ui/lastfmpanel/LastFMPanel.cpp:1251
 #: ui/lastfmpanel/LastFMPanel.cpp:1468 ui/lastfmpanel/LastFMPanel.cpp:3244
-#: ui/radios/RadioPanel.cpp:440 ui/podcasts/PodcastsPanel.cpp:2084
+#: ui/radios/RadioPanel.cpp:432 ui/podcasts/PodcastsPanel.cpp:2066
+#: ui/filebrowser/FileBrowser.cpp:359 ui/filebrowser/FileBrowser.cpp:1138
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:661
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:241
+#: ui/mediaviewer/treeview/TreePanel.cpp:403
+#: ui/mediaviewer/library/PcListBox.cpp:130
+#: ui/mediaviewer/library/TaListBox.cpp:143
+#: ui/mediaviewer/library/GeListBox.cpp:112
+#: ui/mediaviewer/library/RaListBox.cpp:162
+#: ui/mediaviewer/library/ArListBox.cpp:167
+#: ui/mediaviewer/library/YeListBox.cpp:123
+#: ui/mediaviewer/library/AAListBox.cpp:164
+#: ui/mediaviewer/library/SoListBox.cpp:540
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:353
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1947
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2082
-#: ui/mediaviewer/treeview/TreePanel.cpp:407
-#: ui/mediaviewer/library/ArListBox.cpp:168
-#: ui/mediaviewer/library/GeListBox.cpp:112
-#: ui/mediaviewer/library/SoListBox.cpp:543
-#: ui/mediaviewer/library/RaListBox.cpp:163
-#: ui/mediaviewer/library/TaListBox.cpp:143
-#: ui/mediaviewer/library/AAListBox.cpp:165
-#: ui/mediaviewer/library/YeListBox.cpp:123
-#: ui/mediaviewer/library/PcListBox.cpp:131
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:241
-#: ui/filebrowser/FileBrowser.cpp:359 ui/filebrowser/FileBrowser.cpp:1138
 msgid "Add current selected tracks to playlist after the current track"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:579 ui/lastfmpanel/LastFMPanel.cpp:850
 #: ui/lastfmpanel/LastFMPanel.cpp:1050 ui/lastfmpanel/LastFMPanel.cpp:1256
 #: ui/lastfmpanel/LastFMPanel.cpp:1473 ui/lastfmpanel/LastFMPanel.cpp:3249
-#: ui/radios/RadioPanel.cpp:446 ui/podcasts/PodcastsPanel.cpp:2089
+#: ui/radios/RadioPanel.cpp:438 ui/podcasts/PodcastsPanel.cpp:2071
+#: ui/filebrowser/FileBrowser.cpp:364 ui/filebrowser/FileBrowser.cpp:1144
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:666
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:246
+#: ui/mediaviewer/treeview/TreePanel.cpp:408
+#: ui/mediaviewer/library/PcListBox.cpp:136
+#: ui/mediaviewer/library/TaListBox.cpp:149
+#: ui/mediaviewer/library/GeListBox.cpp:118
+#: ui/mediaviewer/library/RaListBox.cpp:168
+#: ui/mediaviewer/library/CoListBox.cpp:129
+#: ui/mediaviewer/library/AlListBox.cpp:286
+#: ui/mediaviewer/library/ArListBox.cpp:173
+#: ui/mediaviewer/library/YeListBox.cpp:129
+#: ui/mediaviewer/library/AAListBox.cpp:170
+#: ui/mediaviewer/library/SoListBox.cpp:546
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:358
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1952
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2087
-#: ui/mediaviewer/treeview/TreePanel.cpp:412
-#: ui/mediaviewer/library/CoListBox.cpp:129
-#: ui/mediaviewer/library/ArListBox.cpp:174
-#: ui/mediaviewer/library/GeListBox.cpp:118
-#: ui/mediaviewer/library/SoListBox.cpp:549
-#: ui/mediaviewer/library/AlListBox.cpp:287
-#: ui/mediaviewer/library/RaListBox.cpp:169
-#: ui/mediaviewer/library/TaListBox.cpp:149
-#: ui/mediaviewer/library/AAListBox.cpp:171
-#: ui/mediaviewer/library/YeListBox.cpp:129
-#: ui/mediaviewer/library/PcListBox.cpp:137
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:246
-#: ui/filebrowser/FileBrowser.cpp:364 ui/filebrowser/FileBrowser.cpp:1144
 msgid "Current Album"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:580 ui/lastfmpanel/LastFMPanel.cpp:851
 #: ui/lastfmpanel/LastFMPanel.cpp:1051 ui/lastfmpanel/LastFMPanel.cpp:1257
 #: ui/lastfmpanel/LastFMPanel.cpp:1474 ui/lastfmpanel/LastFMPanel.cpp:3250
-#: ui/radios/RadioPanel.cpp:447 ui/podcasts/PodcastsPanel.cpp:2090
+#: ui/radios/RadioPanel.cpp:439 ui/podcasts/PodcastsPanel.cpp:2072
+#: ui/filebrowser/FileBrowser.cpp:365 ui/filebrowser/FileBrowser.cpp:1145
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:667
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:247
+#: ui/mediaviewer/treeview/TreePanel.cpp:409
+#: ui/mediaviewer/library/PcListBox.cpp:137
+#: ui/mediaviewer/library/TaListBox.cpp:150
+#: ui/mediaviewer/library/GeListBox.cpp:119
+#: ui/mediaviewer/library/RaListBox.cpp:169
+#: ui/mediaviewer/library/ArListBox.cpp:174
+#: ui/mediaviewer/library/YeListBox.cpp:130
+#: ui/mediaviewer/library/AAListBox.cpp:171
+#: ui/mediaviewer/library/SoListBox.cpp:547
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:359
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1953
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2088
-#: ui/mediaviewer/treeview/TreePanel.cpp:413
-#: ui/mediaviewer/library/ArListBox.cpp:175
-#: ui/mediaviewer/library/GeListBox.cpp:119
-#: ui/mediaviewer/library/SoListBox.cpp:550
-#: ui/mediaviewer/library/RaListBox.cpp:170
-#: ui/mediaviewer/library/TaListBox.cpp:150
-#: ui/mediaviewer/library/AAListBox.cpp:172
-#: ui/mediaviewer/library/YeListBox.cpp:130
-#: ui/mediaviewer/library/PcListBox.cpp:138
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:247
-#: ui/filebrowser/FileBrowser.cpp:365 ui/filebrowser/FileBrowser.cpp:1145
 msgid "Add current selected tracks to playlist after the current album"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:585 ui/lastfmpanel/LastFMPanel.cpp:856
 #: ui/lastfmpanel/LastFMPanel.cpp:1056 ui/lastfmpanel/LastFMPanel.cpp:1262
 #: ui/lastfmpanel/LastFMPanel.cpp:1479 ui/lastfmpanel/LastFMPanel.cpp:3255
-#: ui/radios/RadioPanel.cpp:453 ui/podcasts/PodcastsPanel.cpp:2095
+#: ui/radios/RadioPanel.cpp:445 ui/podcasts/PodcastsPanel.cpp:2077
+#: ui/filebrowser/FileBrowser.cpp:370 ui/filebrowser/FileBrowser.cpp:1151
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:672
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:252
+#: ui/mediaviewer/treeview/TreePanel.cpp:414
+#: ui/mediaviewer/library/PcListBox.cpp:143
+#: ui/mediaviewer/library/TaListBox.cpp:156
+#: ui/mediaviewer/library/GeListBox.cpp:125
+#: ui/mediaviewer/library/RaListBox.cpp:175
+#: ui/mediaviewer/library/CoListBox.cpp:136
+#: ui/mediaviewer/library/AlListBox.cpp:292
+#: ui/mediaviewer/library/ArListBox.cpp:180
+#: ui/mediaviewer/library/YeListBox.cpp:136
+#: ui/mediaviewer/library/AAListBox.cpp:177
+#: ui/mediaviewer/library/SoListBox.cpp:553
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:364
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1958
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2093
-#: ui/mediaviewer/treeview/TreePanel.cpp:418
-#: ui/mediaviewer/library/CoListBox.cpp:136
-#: ui/mediaviewer/library/ArListBox.cpp:181
-#: ui/mediaviewer/library/GeListBox.cpp:125
-#: ui/mediaviewer/library/SoListBox.cpp:556
-#: ui/mediaviewer/library/AlListBox.cpp:293
-#: ui/mediaviewer/library/RaListBox.cpp:176
-#: ui/mediaviewer/library/TaListBox.cpp:156
-#: ui/mediaviewer/library/AAListBox.cpp:178
-#: ui/mediaviewer/library/YeListBox.cpp:136
-#: ui/mediaviewer/library/PcListBox.cpp:144
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:252
-#: ui/filebrowser/FileBrowser.cpp:370 ui/filebrowser/FileBrowser.cpp:1151
 msgid "Current Artist"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:586 ui/lastfmpanel/LastFMPanel.cpp:857
 #: ui/lastfmpanel/LastFMPanel.cpp:1057 ui/lastfmpanel/LastFMPanel.cpp:1263
 #: ui/lastfmpanel/LastFMPanel.cpp:1480 ui/lastfmpanel/LastFMPanel.cpp:3256
-#: ui/radios/RadioPanel.cpp:454 ui/podcasts/PodcastsPanel.cpp:2096
+#: ui/radios/RadioPanel.cpp:446 ui/podcasts/PodcastsPanel.cpp:2078
+#: ui/filebrowser/FileBrowser.cpp:371 ui/filebrowser/FileBrowser.cpp:1152
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:673
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:253
+#: ui/mediaviewer/treeview/TreePanel.cpp:415
+#: ui/mediaviewer/library/PcListBox.cpp:144
+#: ui/mediaviewer/library/TaListBox.cpp:157
+#: ui/mediaviewer/library/GeListBox.cpp:126
+#: ui/mediaviewer/library/RaListBox.cpp:176
+#: ui/mediaviewer/library/ArListBox.cpp:181
+#: ui/mediaviewer/library/YeListBox.cpp:137
+#: ui/mediaviewer/library/AAListBox.cpp:178
+#: ui/mediaviewer/library/SoListBox.cpp:554
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:365
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1959
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2094
-#: ui/mediaviewer/treeview/TreePanel.cpp:419
-#: ui/mediaviewer/library/ArListBox.cpp:182
-#: ui/mediaviewer/library/GeListBox.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:557
-#: ui/mediaviewer/library/RaListBox.cpp:177
-#: ui/mediaviewer/library/TaListBox.cpp:157
-#: ui/mediaviewer/library/AAListBox.cpp:179
-#: ui/mediaviewer/library/YeListBox.cpp:137
-#: ui/mediaviewer/library/PcListBox.cpp:145
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:253
-#: ui/filebrowser/FileBrowser.cpp:371 ui/filebrowser/FileBrowser.cpp:1152
 msgid "Add current selected tracks to playlist after the current artist"
 msgstr ""
 
 #: ui/lastfmpanel/LastFMPanel.cpp:590 ui/lastfmpanel/LastFMPanel.cpp:861
 #: ui/lastfmpanel/LastFMPanel.cpp:1061 ui/lastfmpanel/LastFMPanel.cpp:1267
 #: ui/lastfmpanel/LastFMPanel.cpp:1484 ui/lastfmpanel/LastFMPanel.cpp:3260
-#: ui/radios/RadioPanel.cpp:459 ui/podcasts/PodcastsPanel.cpp:2100
+#: ui/radios/RadioPanel.cpp:451 ui/podcasts/PodcastsPanel.cpp:2082
+#: ui/filebrowser/FileBrowser.cpp:375 ui/filebrowser/FileBrowser.cpp:1157
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:677
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:257
+#: ui/mediaviewer/treeview/TreePanel.cpp:419
+#: ui/mediaviewer/library/PcListBox.cpp:149
+#: ui/mediaviewer/library/TaListBox.cpp:162
+#: ui/mediaviewer/library/GeListBox.cpp:131
+#: ui/mediaviewer/library/RaListBox.cpp:181
+#: ui/mediaviewer/library/CoListBox.cpp:142
+#: ui/mediaviewer/library/AlListBox.cpp:297
+#: ui/mediaviewer/library/ArListBox.cpp:186
+#: ui/mediaviewer/library/YeListBox.cpp:142
+#: ui/mediaviewer/library/AAListBox.cpp:183
+#: ui/mediaviewer/library/SoListBox.cpp:559
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:369
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1963
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2098
-#: ui/mediaviewer/treeview/TreePanel.cpp:423
-#: ui/mediaviewer/library/CoListBox.cpp:142
-#: ui/mediaviewer/library/ArListBox.cpp:187
-#: ui/mediaviewer/library/GeListBox.cpp:131
-#: ui/mediaviewer/library/SoListBox.cpp:562
-#: ui/mediaviewer/library/AlListBox.cpp:298
-#: ui/mediaviewer/library/RaListBox.cpp:182
-#: ui/mediaviewer/library/TaListBox.cpp:162
-#: ui/mediaviewer/library/AAListBox.cpp:184
-#: ui/mediaviewer/library/YeListBox.cpp:142
-#: ui/mediaviewer/library/PcListBox.cpp:150
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:257
-#: ui/filebrowser/FileBrowser.cpp:375 ui/filebrowser/FileBrowser.cpp:1157
 msgid "Enqueue After"
 msgstr ""
 
@@ -455,8 +372,15 @@ msgstr ""
 msgid "Follow player"
 msgstr ""
 
+#: ui/lastfmpanel/LastFMPanel.cpp:1726 ui/cover/CoverEdit.cpp:78
+#: ui/lyrics/LyricsPanel.cpp:114 ui/trackedit/TrackEdit.cpp:162
+#: ui/trackedit/TrackEdit.cpp:387 ui/trackedit/TrackEdit.cpp:428
+#: ui/trackedit/TrackEdit.cpp:487
+msgid "Artist:"
+msgstr ""
+
 #: ui/lastfmpanel/LastFMPanel.cpp:1735 ui/lyrics/LyricsPanel.cpp:124
-#: ui/trackedit/TrackEdit.cpp:396
+#: ui/trackedit/TrackEdit.cpp:394
 msgid "Track:"
 msgstr ""
 
@@ -484,35 +408,34 @@ msgstr ""
 msgid "Events"
 msgstr ""
 
-#: ui/lastfmpanel/LastFMPanel.cpp:3264
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2116
-#: ui/mediaviewer/treeview/TreePanel.cpp:454
-#: ui/mediaviewer/library/CoListBox.cpp:160
-#: ui/mediaviewer/library/ArListBox.cpp:211
-#: ui/mediaviewer/library/GeListBox.cpp:138
-#: ui/mediaviewer/library/SoListBox.cpp:624
-#: ui/mediaviewer/library/AlListBox.cpp:339
-#: ui/mediaviewer/library/RaListBox.cpp:200
-#: ui/mediaviewer/library/TaListBox.cpp:169
-#: ui/mediaviewer/library/AAListBox.cpp:202
-#: ui/mediaviewer/library/YeListBox.cpp:160
-#: ui/mediaviewer/library/PcListBox.cpp:168
+#: ui/lastfmpanel/LastFMPanel.cpp:3264 ui/filebrowser/FileBrowser.cpp:388
+#: ui/filebrowser/FileBrowser.cpp:1173 ui/player/PlayList.cpp:1582
 #: ui/mediaviewer/playlists/PlayListPanel.cpp:289
 #: ui/mediaviewer/playlists/PlayListAppend.cpp:28
-#: ui/filebrowser/FileBrowser.cpp:388 ui/filebrowser/FileBrowser.cpp:1173
-#: ui/player/PlayList.cpp:1598 misc/Accelerators.cpp:144
+#: ui/mediaviewer/treeview/TreePanel.cpp:450
+#: ui/mediaviewer/library/PcListBox.cpp:167
+#: ui/mediaviewer/library/TaListBox.cpp:169
+#: ui/mediaviewer/library/GeListBox.cpp:138
+#: ui/mediaviewer/library/RaListBox.cpp:199
+#: ui/mediaviewer/library/CoListBox.cpp:160
+#: ui/mediaviewer/library/AlListBox.cpp:338
+#: ui/mediaviewer/library/ArListBox.cpp:210
+#: ui/mediaviewer/library/YeListBox.cpp:160
+#: ui/mediaviewer/library/AAListBox.cpp:201
+#: ui/mediaviewer/library/SoListBox.cpp:621
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2116 misc/Accelerators.cpp:144
 msgid "Save to Playlist"
 msgstr ""
 
-#: ui/lastfmpanel/LastFMPanel.cpp:3264
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2117
-#: ui/mediaviewer/treeview/TreePanel.cpp:455
-#: ui/mediaviewer/library/CoListBox.cpp:161
-#: ui/mediaviewer/library/ArListBox.cpp:212
-#: ui/mediaviewer/library/GeListBox.cpp:139
-#: ui/mediaviewer/library/RaListBox.cpp:201
+#: ui/lastfmpanel/LastFMPanel.cpp:3264 ui/player/PlayList.cpp:1583
+#: ui/mediaviewer/treeview/TreePanel.cpp:451
+#: ui/mediaviewer/library/PcListBox.cpp:168
 #: ui/mediaviewer/library/TaListBox.cpp:170
-#: ui/mediaviewer/library/PcListBox.cpp:169 ui/player/PlayList.cpp:1599
+#: ui/mediaviewer/library/GeListBox.cpp:139
+#: ui/mediaviewer/library/RaListBox.cpp:200
+#: ui/mediaviewer/library/CoListBox.cpp:161
+#: ui/mediaviewer/library/ArListBox.cpp:211
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2117
 msgid "Save the selected tracks to playlist"
 msgstr ""
 
@@ -520,18 +443,208 @@ msgstr ""
 msgid "Unnamed"
 msgstr ""
 
-#: ui/radios/RadioEditor.cpp:47 ui/lyrics/LyricsPanel.cpp:2114
-#: ui/preferences/Preferences.cpp:2050 ui/preferences/Preferences.cpp:2171
-#: ui/preferences/Preferences.cpp:2296
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:701
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:48
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:462
-#: ui/filebrowser/FileRenamer.cpp:70
-msgid "Name:"
+#: ui/cover/SelCoverFile.cpp:34
+msgid "Select Cover File"
 msgstr ""
 
-#: ui/radios/RadioEditor.cpp:55 ui/podcasts/PodcastsPanel.cpp:984
-msgid "Link:"
+#: ui/cover/SelCoverFile.cpp:44 ui/mediaviewer/MediaViewer.cpp:1476
+msgid ""
+"Could not find the Album in the songs library.\n"
+"You should update the library."
+msgstr ""
+
+#: ui/cover/SelCoverFile.cpp:45 ui/filebrowser/FileBrowser.cpp:578
+#: ui/mediaviewer/MediaViewer.cpp:1477
+msgid "Error"
+msgstr ""
+
+#: ui/cover/SelCoverFile.cpp:60
+msgid "Cover:"
+msgstr ""
+
+#: ui/cover/SelCoverFile.cpp:72 ui/cover/CoverEdit.cpp:113
+msgid "Embed into tracks"
+msgstr ""
+
+#: ui/cover/SelCoverFile.cpp:122 ui/cover/CoverEdit.cpp:581
+msgid "Select the cover filename"
+msgstr ""
+
+#: ui/cover/CoverEdit.cpp:59
+msgid "Cover Editor"
+msgstr ""
+
+#: ui/cover/CoverEdit.cpp:85 ui/trackedit/TrackEdit.cpp:186
+#: ui/trackedit/TrackEdit.cpp:453 ui/trackedit/TrackEdit.cpp:509
+msgid "Album:"
+msgstr ""
+
+#: ui/cover/CoverEdit.cpp:92
+msgid "From:"
+msgstr ""
+
+#: ui/cover/CoverEdit.cpp:608
+msgid "Cover Url"
+msgstr ""
+
+#: ui/splash/SplashWin.cpp:77
+msgid "Please Donate!"
+msgstr ""
+
+#: ui/statusbar/StatusBar.cpp:157 ui/statusbar/StatusBar.cpp:217
+msgid "Enable audioscrobbling"
+msgstr ""
+
+#: ui/statusbar/StatusBar.cpp:160
+msgid "Shows information about the selected items"
+msgstr ""
+
+#: ui/statusbar/StatusBar.cpp:217
+msgid "Disable audioscrobbling"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:73
+msgid " Items "
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:93
+msgid " Labels "
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:121
+msgid "Add a new label"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:127
+msgid "Delete the current selected label"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:133
+msgid "Copy the label selection to all the items"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:287 ui/mediaviewer/library/TaListBox.cpp:188
+#: ui/mediaviewer/library/TaListBox.cpp:229
+msgid "Label Name: "
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:287 ui/mediaviewer/library/TaListBox.cpp:188
+msgid "Please enter the label name"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:310 ui/mediaviewer/library/TaListBox.cpp:205
+msgid "Are you sure to delete the selected labels?"
+msgstr ""
+
+#: ui/labeleditor/LabelEditor.cpp:311 ui/radios/ShoutcastRadio.cpp:367
+#: ui/radios/ShoutcastRadio.cpp:446 ui/podcasts/PodcastsPanel.cpp:1246
+#: ui/podcasts/PodcastsPanel.cpp:1628 ui/filebrowser/FileBrowser.cpp:567
+#: ui/filebrowser/FileBrowser.cpp:2217
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1073
+#: ui/mediaviewer/treeview/TreePanel.cpp:1221
+#: ui/mediaviewer/library/TaListBox.cpp:206
+#: ui/mediaviewer/library/LibPanel.cpp:1227 MainApp.cpp:341
+msgid "Confirm"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:645 ui/player/PlayerPanel.cpp:1489
+#: db/DbLibrary.cpp:288 db/DbLibrary.cpp:300 db/DbLibrary.cpp:1771
+#: db/DbLibrary.cpp:1783 db/DbLibrary.cpp:1856 db/DbLibrary.cpp:1868
+msgid "Unknown"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1118 ui/jamendo/Jamendo.cpp:1128
+#: ui/magnatune/Magnatune.cpp:1012 ui/magnatune/Magnatune.cpp:1019
+msgid "Download Albums"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1118 ui/jamendo/Jamendo.cpp:1121
+#: ui/jamendo/Jamendo.cpp:1128 ui/jamendo/Jamendo.cpp:1131
+#: ui/magnatune/Magnatune.cpp:1012 ui/magnatune/Magnatune.cpp:1019
+msgid "Download the current selected album"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1121 ui/jamendo/Jamendo.cpp:1131
+msgid "Download Albums torrents"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1137 ui/podcasts/PodcastsPanel.cpp:1764
+#: ui/locationpanel/LocationPanel.cpp:335
+#: ui/locationpanel/LocationPanel.cpp:373
+#: ui/locationpanel/LocationPanel.cpp:508 ui/MainFrame.cpp:1067
+#: ui/MainFrame.cpp:1105 ui/MainFrame.cpp:1338
+#: ui/filebrowser/FileBrowser.cpp:420 ui/magnatune/Magnatune.cpp:1026
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1612
+#: ui/mediaviewer/MediaViewer.cpp:969
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1448 misc/Accelerators.cpp:170
+msgid "Update"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1137 ui/locationpanel/LocationPanel.cpp:509
+#: ui/MainFrame.cpp:1339 ui/magnatune/Magnatune.cpp:1026
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1612
+#: ui/mediaviewer/MediaViewer.cpp:969
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1448
+msgid "Update the collection library"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1140 ui/locationpanel/LocationPanel.cpp:514
+#: ui/MainFrame.cpp:1344 ui/magnatune/Magnatune.cpp:1029
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1615
+#: ui/mediaviewer/MediaViewer.cpp:972
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1451
+msgid "Rescan"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1140 ui/locationpanel/LocationPanel.cpp:515
+#: ui/MainFrame.cpp:1345 ui/magnatune/Magnatune.cpp:1029
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1615
+#: ui/mediaviewer/MediaViewer.cpp:972
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1451
+msgid "Rescan the collection library"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1143 ui/locationpanel/LocationPanel.cpp:520
+#: ui/MainFrame.cpp:1350 ui/magnatune/Magnatune.cpp:1032
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1618
+#: ui/mediaviewer/MediaViewer.cpp:975
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1454
+msgid "Search Covers"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1143 ui/locationpanel/LocationPanel.cpp:521
+#: ui/MainFrame.cpp:1351 ui/magnatune/Magnatune.cpp:1032
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1618
+#: ui/mediaviewer/MediaViewer.cpp:975
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1454
+msgid "Search the collection missing covers"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1148 ui/podcasts/PodcastsPanel.cpp:1770
+#: ui/locationpanel/LocationPanel.cpp:342
+#: ui/locationpanel/LocationPanel.cpp:381
+#: ui/locationpanel/LocationPanel.cpp:536 ui/MainFrame.cpp:1074
+#: ui/MainFrame.cpp:1113 ui/MainFrame.cpp:1366 ui/magnatune/Magnatune.cpp:1037
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1628
+#: ui/mediaviewer/MediaViewer.cpp:980
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1464
+msgid "Properties"
+msgstr ""
+
+#: ui/jamendo/Jamendo.cpp:1148 ui/locationpanel/LocationPanel.cpp:536
+#: ui/MainFrame.cpp:1366 ui/magnatune/Magnatune.cpp:1037
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1628
+#: ui/mediaviewer/MediaViewer.cpp:980
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1464
+msgid "Show collection properties"
+msgstr ""
+
+#: ui/equalizer/Equalizer.cpp:72
+msgid "Equalizer"
+msgstr ""
+
+#: ui/equalizer/Equalizer.cpp:114
+msgid "Preset:"
 msgstr ""
 
 #: ui/radios/UserRadio.cpp:58
@@ -583,8 +696,8 @@ msgstr ""
 msgid "Radio Genre Editor"
 msgstr ""
 
-#: ui/radios/RadioGenreEditor.cpp:40 ui/preferences/Preferences.cpp:1738
-#: ui/preferences/Preferences.cpp:1830
+#: ui/radios/RadioGenreEditor.cpp:40 ui/preferences/Preferences.cpp:1735
+#: ui/preferences/Preferences.cpp:1827
 msgid " Genres "
 msgstr ""
 
@@ -592,105 +705,103 @@ msgstr ""
 msgid "Other:"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:331
+#: ui/radios/RadioPanel.cpp:323 ui/filebrowser/FileBrowser.cpp:775
+#: ui/mediaviewer/library/AlListBox.cpp:321
 #: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:424
-#: ui/mediaviewer/library/AlListBox.cpp:322 ui/filebrowser/FileBrowser.cpp:775
 msgid "Name"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:332
+#: ui/radios/RadioPanel.cpp:324
 msgid "BitRate"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:333
+#: ui/radios/RadioPanel.cpp:325
 msgid "Listeners"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:334 ui/mediaviewer/library/SoListBox.cpp:75
+#: ui/radios/RadioPanel.cpp:326 ui/mediaviewer/library/SoListBox.cpp:75
 msgid "Format"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:335 ui/player/PlayList.cpp:82 ui/MainFrame.cpp:356
-#: ui/MainFrame.cpp:611 ui/MainFrame.cpp:2153 ui/MainFrame.cpp:2928
-#: ui/MainFrame.cpp:2945
+#: ui/radios/RadioPanel.cpp:327 ui/MainFrame.cpp:356 ui/MainFrame.cpp:611
+#: ui/MainFrame.cpp:2153 ui/MainFrame.cpp:2928 ui/MainFrame.cpp:2945
+#: ui/player/PlayList.cpp:82
 msgid "Now Playing"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:426 ui/podcasts/PodcastsPanel.cpp:2070
-#: ui/mediaviewer/treeview/TreePanel.cpp:393
-#: ui/mediaviewer/library/SoListBox.cpp:527
+#: ui/radios/RadioPanel.cpp:418 ui/podcasts/PodcastsPanel.cpp:2052
 #: ui/mediaviewer/playlists/PlayListPanel.cpp:227
+#: ui/mediaviewer/treeview/TreePanel.cpp:389
+#: ui/mediaviewer/library/SoListBox.cpp:524
 msgid "Play current selected songs"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:432 ui/podcasts/PodcastsPanel.cpp:2076
+#: ui/radios/RadioPanel.cpp:424 ui/podcasts/PodcastsPanel.cpp:2058
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:653
 msgid "Add current selected songs to playlist"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:464
+#: ui/radios/RadioPanel.cpp:456
 msgid "Add to User Radio"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:465
+#: ui/radios/RadioPanel.cpp:457
 msgid "Add selected radios as user radios"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:579 ui/radios/RadioPanel.cpp:621
+#: ui/radios/RadioPanel.cpp:569 ui/radios/RadioPanel.cpp:611
 #: ui/locationpanel/LocationPanel.cpp:318 ui/MainFrame.cpp:1050
 msgid "Text Search"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:595 ui/radios/ShoutcastRadio.cpp:142
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:364
+#: ui/radios/RadioPanel.cpp:585 ui/radios/ShoutcastRadio.cpp:142
+#: ui/player/PlayList.cpp:1654 ui/mediaviewer/audiocd/AudioCdPanel.cpp:364
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:53
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:133
 #: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:66
 #: ui/mediaviewer/library/SoListBox.cpp:65
-#: ui/mediaviewer/library/SoListBox.cpp:655
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:53
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:133 ui/player/PlayList.cpp:1670
+#: ui/mediaviewer/library/SoListBox.cpp:652
 msgid "Genre"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:611 ui/radios/RadioPanel.cpp:625
+#: ui/radios/RadioPanel.cpp:601 ui/radios/RadioPanel.cpp:615
 msgid "Stations"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:623
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
+#: ui/radios/RadioPanel.cpp:613 ui/locationpanel/LocationPanel.cpp:328
+#: ui/locationpanel/LocationPanel.cpp:425 ui/MainFrame.cpp:1060
+#: ui/MainFrame.cpp:1255 ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
 #: ui/mediaviewer/library/LibPanel.cpp:215
 #: ui/mediaviewer/library/LibPanel.cpp:222
 #: ui/mediaviewer/library/LibPanel.cpp:519
-#: ui/locationpanel/LocationPanel.cpp:328
-#: ui/locationpanel/LocationPanel.cpp:425 ui/MainFrame.cpp:1060
-#: ui/MainFrame.cpp:1255
 msgid "Genres"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1159
+#: ui/radios/RadioPanel.cpp:1144
 msgid "There are not entries for this Radio Station"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1208
+#: ui/radios/RadioPanel.cpp:1193
 msgid " Radio Search "
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1213 ui/lyrics/LyricsPanel.cpp:2571
+#: ui/radios/RadioPanel.cpp:1198 ui/lyrics/LyricsPanel.cpp:2571
 msgid "Search:"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1223
+#: ui/radios/RadioPanel.cpp:1208
 msgid "Search in now playing info"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1227
+#: ui/radios/RadioPanel.cpp:1212
 msgid "Search in genre names"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1231
+#: ui/radios/RadioPanel.cpp:1216
 msgid "Search in station names"
 msgstr ""
 
-#: ui/radios/RadioPanel.cpp:1235
+#: ui/radios/RadioPanel.cpp:1220
 msgid "Include results from all genres"
 msgstr ""
 
@@ -750,603 +861,250 @@ msgstr ""
 msgid "Searches"
 msgstr ""
 
-#: ui/radios/ShoutcastRadio.cpp:275 ui/locationpanel/LocationPanel.cpp:206
+#: ui/radios/ShoutcastRadio.cpp:271 ui/locationpanel/LocationPanel.cpp:206
 msgid "Radios"
 msgstr ""
 
-#: ui/radios/ShoutcastRadio.cpp:345
+#: ui/radios/ShoutcastRadio.cpp:340
 msgid "Genre Name: "
 msgstr ""
 
-#: ui/radios/ShoutcastRadio.cpp:345
+#: ui/radios/ShoutcastRadio.cpp:340
 msgid "Enter the new Genre Name"
 msgstr ""
 
-#: ui/radios/ShoutcastRadio.cpp:372
+#: ui/radios/ShoutcastRadio.cpp:366
 msgid "Are you sure to delete the selected radio genres?"
 msgstr ""
 
-#: ui/radios/ShoutcastRadio.cpp:373 ui/radios/ShoutcastRadio.cpp:453
-#: ui/labeleditor/LabelEditor.cpp:311 ui/podcasts/PodcastsPanel.cpp:1250
-#: ui/podcasts/PodcastsPanel.cpp:1636
-#: ui/mediaviewer/treeview/TreePanel.cpp:1232
-#: ui/mediaviewer/library/LibPanel.cpp:1227
-#: ui/mediaviewer/library/TaListBox.cpp:206
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1083
-#: ui/filebrowser/FileBrowser.cpp:567 ui/filebrowser/FileBrowser.cpp:2217
-#: MainApp.cpp:341
-msgid "Confirm"
-msgstr ""
-
-#: ui/radios/ShoutcastRadio.cpp:452
+#: ui/radios/ShoutcastRadio.cpp:445
 msgid "Are you sure to delete the selected radio searches?"
 msgstr ""
 
-#: ui/equalizer/Equalizer.cpp:72
-msgid "Equalizer"
+#: ui/radios/RadioEditor.cpp:47 ui/preferences/Preferences.cpp:2045
+#: ui/preferences/Preferences.cpp:2165 ui/preferences/Preferences.cpp:2289
+#: ui/filebrowser/FileRenamer.cpp:70 ui/lyrics/LyricsPanel.cpp:2114
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:697
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:459
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:48
+msgid "Name:"
 msgstr ""
 
-#: ui/equalizer/Equalizer.cpp:114
-msgid "Preset:"
+#: ui/radios/RadioEditor.cpp:55 ui/podcasts/PodcastsPanel.cpp:981
+msgid "Link:"
 msgstr ""
 
-#: ui/labeleditor/LabelEditor.cpp:73
-msgid " Items "
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:93
-msgid " Labels "
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:121
-msgid "Add a new label"
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:127
-msgid "Delete the current selected label"
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:133
-msgid "Copy the label selection to all the items"
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:287 ui/mediaviewer/library/TaListBox.cpp:188
-#: ui/mediaviewer/library/TaListBox.cpp:229
-msgid "Label Name: "
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:287 ui/mediaviewer/library/TaListBox.cpp:188
-msgid "Please enter the label name"
-msgstr ""
-
-#: ui/labeleditor/LabelEditor.cpp:310 ui/mediaviewer/library/TaListBox.cpp:205
-msgid "Are you sure to delete the selected labels?"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:85
-msgid "Search the lyrics for the current playing track"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:91
-msgid "Configure lyrics preferences"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:95 ui/trackedit/TrackEdit.cpp:404
-msgid "Search for lyrics"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:100
-msgid "Edit the lyrics"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:106
-msgid "Save the lyrics"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:111
-msgid "Search the lyrics on the web"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:289
-msgid "Copy the content of the lyric to clipboard"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:301 ui/filebrowser/FileBrowser.cpp:403
-#: ui/filebrowser/FileBrowser.cpp:1185
-msgid "Paste"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:301
-msgid "Paste the content of the lyric from clipboard"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:310 misc/Accelerators.cpp:410
-msgid "Print"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:310
-msgid "Print the content of the lyrics"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:445 ui/lyrics/LyricsPanel.cpp:564
-#: ui/lyrics/LyricsPanel.cpp:846 ui/lyrics/LyricsPanel.cpp:848
-msgid "Searching..."
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:760 ui/lyrics/LyricsPanel.cpp:852
-msgid "No lyrics found"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:844
-msgid "Lyrics from "
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2090
-msgid "Lyrics Target Editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2090
-msgid "Lyrics Source Editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2123
-msgid "Type:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2128
-msgid "Embedded"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2129
-msgid "File"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2130
-msgid "Command"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2132 ui/podcasts/PodcastsPanel.cpp:2110
-msgid "Download"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2139
-msgid "Source:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2147 ui/lyrics/LyricsPanel.cpp:2572
-msgid "Replace:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2181
-msgid "Extract:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2211
-msgid "Exclude:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2241
-msgid "Not Found:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2570
-msgid "Replace option editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2576
-msgid "Extract option editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2577 ui/lyrics/LyricsPanel.cpp:2583
-msgid "Begin:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2578 ui/lyrics/LyricsPanel.cpp:2584
-msgid "End:"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2582
-msgid "Exclude option editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2588
-msgid "Not Found option editor"
-msgstr ""
-
-#: ui/lyrics/LyricsPanel.cpp:2589 ui/lyrics/LyricsPanel.cpp:2590
-msgid "Tag:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:105
-msgid "Songs Editor"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:118
-msgid " Songs "
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:126
-msgid "Move the track to the previous position"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:132
-msgid "Move the track to the next position"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:161
-msgid "Copy the artist name to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:173
-msgid "Copy the album artist name to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:176 ui/trackedit/TrackEdit.cpp:500
-msgid "A. Artist:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:177
-msgid "shows the album artist of the track"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:185
-msgid "Copy the album name to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:196
-msgid "Copy the title to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:199 ui/trackedit/TrackEdit.cpp:438
-#: ui/trackedit/TrackEdit.cpp:533 ui/podcasts/PodcastsPanel.cpp:999
-msgid "Title:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:207
-msgid "Copy the composer to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:211
-msgid "Composer:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:219
-msgid "Copy the comment to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:223
-msgid "Comment:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:232
-msgid "Copy the number to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:235 ui/trackedit/TrackEdit.cpp:556
-msgid "Number:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:249
-msgid "Enumerate the tracks in the order they were added for editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:255
-msgid "Copy the disk to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:259
-msgid "Disk:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:269
-msgid "Copy the genre name to all songs you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:272
-msgid "Genre:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:280
-msgid "Copy the year to all songs you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:283 ui/trackedit/TrackEdit.cpp:522
-msgid "Year:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:299
-msgid "Rating:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:326 ui/podcasts/PodcastsPanel.cpp:1065
-#: ui/locationpanel/LocationPanel.cpp:365 ui/MainFrame.cpp:1097
-msgid "Details"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:348
-msgid "Add a picture from file to the current track"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:352
-msgid "Delete the picture from the current track"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:356
-msgid "Save the current picture to file"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:360
-msgid "Search the album cover"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:369
-msgid "Copy the current picture to all the tracks you are editing"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:377
-msgid "Pictures"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:416 ui/preferences/Preferences.cpp:258
-#: ui/locationpanel/LocationPanel.cpp:290 ui/MainFrame.cpp:1444
-#: ui/MainFrame.cpp:2800
-msgid "Lyrics"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:435
-msgid "Type the artist name to search in musicbrainz"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:443
-msgid "Type the album name to search in musicbrainz"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:447
-msgid "Clear the search fields so it search using the music fingerprint"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:461
-msgid "Select the album found in musicbrainz"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:467
-msgid "Search albums in musicbrainz"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:473
-msgid "Copy the content of the album to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:481 ui/podcasts/PodcastsPanel.cpp:933
-msgid " Details "
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:497
-msgid "Copy the artist to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:508
-msgid "Copy the album artist to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:519
-msgid "Copy the album to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:530
-msgid "Copy the date to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:541
-msgid "Copy the song names to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:544 ui/podcasts/PodcastsPanel.cpp:1029
-msgid "Length:"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:566
-msgid "Copy the number to the edited tracks"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:927
-#, c-format
-msgid ""
-"File Type\t: %s\n"
-"Length\t: %s"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:931
-#, c-format
-msgid ""
-"BitRate\t: %u Kbps\n"
-"File Size\t: %s"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:1674
-#, c-format
-msgid "Error: The album have %lu tracks and you are editing %lu"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:1680
-msgid "Warning: The length of some edited tracks don't match"
-msgstr ""
-
-#: ui/trackedit/TrackEdit.cpp:1684
-msgid "Everything ok"
-msgstr ""
-
-#: ui/podcasts/PodcastsPanel.cpp:895 ui/podcasts/PodcastsPanel.cpp:903
-#: ui/podcasts/PodcastsPanel.cpp:1062 ui/locationpanel/LocationPanel.cpp:360
+#: ui/podcasts/PodcastsPanel.cpp:892 ui/podcasts/PodcastsPanel.cpp:900
+#: ui/podcasts/PodcastsPanel.cpp:1059 ui/locationpanel/LocationPanel.cpp:360
 #: ui/MainFrame.cpp:1092
 msgid "Channels"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:921 ui/preferences/Preferences.cpp:268
-#: ui/locationpanel/LocationPanel.cpp:211 ui/MainFrame.cpp:1117
+#: ui/podcasts/PodcastsPanel.cpp:918 ui/locationpanel/LocationPanel.cpp:211
+#: ui/preferences/Preferences.cpp:267 ui/MainFrame.cpp:1117
 #: ui/MainFrame.cpp:2829 ui/MainFrame.cpp:3557
 msgid "Podcasts"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:953 ui/podcasts/ChannelEditor.cpp:102
+#: ui/podcasts/PodcastsPanel.cpp:930 ui/trackedit/TrackEdit.cpp:479
+msgid " Details "
+msgstr ""
+
+#: ui/podcasts/PodcastsPanel.cpp:950 ui/podcasts/ChannelEditor.cpp:102
 msgid "Description:"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:963 ui/podcasts/ChannelEditor.cpp:114
+#: ui/podcasts/PodcastsPanel.cpp:960 ui/podcasts/ChannelEditor.cpp:114
 msgid "Author:"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:973 ui/podcasts/ChannelEditor.cpp:124
+#: ui/podcasts/PodcastsPanel.cpp:970 ui/podcasts/ChannelEditor.cpp:124
 msgid "Owner:"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1009
+#: ui/podcasts/PodcastsPanel.cpp:996 ui/trackedit/TrackEdit.cpp:197
+#: ui/trackedit/TrackEdit.cpp:436 ui/trackedit/TrackEdit.cpp:531
+msgid "Title:"
+msgstr ""
+
+#: ui/podcasts/PodcastsPanel.cpp:1006
 msgid "Sumary:"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1019
+#: ui/podcasts/PodcastsPanel.cpp:1016
 msgid "Date:"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1050
+#: ui/podcasts/PodcastsPanel.cpp:1026 ui/trackedit/TrackEdit.cpp:542
+msgid "Length:"
+msgstr ""
+
+#: ui/podcasts/PodcastsPanel.cpp:1047
 msgid "Podcast Details"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1249
+#: ui/podcasts/PodcastsPanel.cpp:1062 ui/locationpanel/LocationPanel.cpp:365
+#: ui/MainFrame.cpp:1097 ui/trackedit/TrackEdit.cpp:324
+msgid "Details"
+msgstr ""
+
+#: ui/podcasts/PodcastsPanel.cpp:1245
 msgid "Are you sure to delete the selected podcast channel?"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1635
+#: ui/podcasts/PodcastsPanel.cpp:1627
 msgid "Are you sure to delete the selected podcast item?"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1764
+#: ui/podcasts/PodcastsPanel.cpp:1752
 msgid "New Channel"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1764
+#: ui/podcasts/PodcastsPanel.cpp:1752
 msgid "Add a new podcast channel"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1770 ui/podcasts/PodcastsPanel.cpp:2104
-#: ui/mediaviewer/treeview/TreePanel.cpp:380
-#: ui/mediaviewer/library/TaListBox.cpp:118
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:299 misc/Accelerators.cpp:385
+#: ui/podcasts/PodcastsPanel.cpp:1758 ui/podcasts/PodcastsPanel.cpp:2086
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:299
+#: ui/mediaviewer/treeview/TreePanel.cpp:376
+#: ui/mediaviewer/library/TaListBox.cpp:118 misc/Accelerators.cpp:385
 msgid "Delete"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1770
+#: ui/podcasts/PodcastsPanel.cpp:1758
 msgid "delete this podcast channels and all its items"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1776 ui/magnatune/Magnatune.cpp:1026
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1622
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1448
-#: ui/mediaviewer/MediaViewer.cpp:969 ui/filebrowser/FileBrowser.cpp:420
-#: ui/locationpanel/LocationPanel.cpp:335
-#: ui/locationpanel/LocationPanel.cpp:373
-#: ui/locationpanel/LocationPanel.cpp:508 ui/MainFrame.cpp:1067
-#: ui/MainFrame.cpp:1105 ui/MainFrame.cpp:1338 ui/jamendo/Jamendo.cpp:1137
-#: misc/Accelerators.cpp:170
-msgid "Update"
-msgstr ""
-
-#: ui/podcasts/PodcastsPanel.cpp:1776
+#: ui/podcasts/PodcastsPanel.cpp:1764
 msgid "Update the podcast items of the selected channels"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1782 ui/magnatune/Magnatune.cpp:1037
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1638
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1464
-#: ui/mediaviewer/MediaViewer.cpp:980 ui/locationpanel/LocationPanel.cpp:342
-#: ui/locationpanel/LocationPanel.cpp:381
-#: ui/locationpanel/LocationPanel.cpp:536 ui/MainFrame.cpp:1074
-#: ui/MainFrame.cpp:1113 ui/MainFrame.cpp:1366 ui/jamendo/Jamendo.cpp:1148
-msgid "Properties"
-msgstr ""
-
-#: ui/podcasts/PodcastsPanel.cpp:1782
+#: ui/podcasts/PodcastsPanel.cpp:1770
 msgid "Edit the podcast channel"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1820
+#: ui/podcasts/PodcastsPanel.cpp:1807
 msgid "Status"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1821
+#: ui/podcasts/PodcastsPanel.cpp:1808
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:360
-#: ui/mediaviewer/library/SoListBox.cpp:61
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:49
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:129
+#: ui/mediaviewer/library/SoListBox.cpp:61
 msgid "Title"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1822
+#: ui/podcasts/PodcastsPanel.cpp:1809
 msgid "Channel"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1823
+#: ui/podcasts/PodcastsPanel.cpp:1810
 msgid "Category"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1824
+#: ui/podcasts/PodcastsPanel.cpp:1811
 msgid "Date"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1825
+#: ui/podcasts/PodcastsPanel.cpp:1812
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:367
-#: ui/mediaviewer/library/SoListBox.cpp:68
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:60
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:138
+#: ui/mediaviewer/library/SoListBox.cpp:68
 msgid "Length"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1826
+#: ui/podcasts/PodcastsPanel.cpp:1813
 msgid "Author"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1827 ui/mediaviewer/library/LibPanel.cpp:326
+#: ui/podcasts/PodcastsPanel.cpp:1814 ui/MainFrame.cpp:1290
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:61
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:139
+#: ui/mediaviewer/library/LibPanel.cpp:326
 #: ui/mediaviewer/library/LibPanel.cpp:333
 #: ui/mediaviewer/library/LibPanel.cpp:531
 #: ui/mediaviewer/library/SoListBox.cpp:72
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:61
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:139 ui/MainFrame.cpp:1290
 msgid "Plays"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1828 ui/mediaviewer/library/SoListBox.cpp:73
+#: ui/podcasts/PodcastsPanel.cpp:1815
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:62
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:140
+#: ui/mediaviewer/library/SoListBox.cpp:73
 msgid "Last Played"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1829
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:448
-#: ui/mediaviewer/library/SoListBox.cpp:74
+#: ui/podcasts/PodcastsPanel.cpp:1816
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:63
 #: ui/mediaviewer/playlists/DynamicPlayList.cpp:141
+#: ui/mediaviewer/library/SoListBox.cpp:74
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:448
 msgid "Added"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:1997 ui/mediaviewer/library/SoListBox.cpp:269
+#: ui/podcasts/PodcastsPanel.cpp:1979 ui/mediaviewer/library/SoListBox.cpp:268
 msgid "Never"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:2104
+#: ui/podcasts/PodcastsPanel.cpp:2086
 msgid "Delete the current selected podcasts"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:2110
+#: ui/podcasts/PodcastsPanel.cpp:2092 ui/lyrics/LyricsPanel.cpp:2132
+msgid "Download"
+msgstr ""
+
+#: ui/podcasts/PodcastsPanel.cpp:2092
 msgid "Download the current selected podcasts"
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:2122
+#: ui/podcasts/PodcastsPanel.cpp:2104
 #: ui/mediaviewer/audiocd/AudioCdPanel.cpp:697
 msgid "No selected items..."
 msgstr ""
 
-#: ui/podcasts/PodcastsPanel.cpp:2122
+#: ui/podcasts/PodcastsPanel.cpp:2104
 msgid "Copy the current selected podcasts to a directory or device"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:89
+msgid "New Podcast Channel"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:102
+msgid " Digital Podcast Directory "
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:113
+msgid "Search in the podcast directory"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:117
+msgid "Refresh the podcast directory list"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:233
+msgid "Filtered channels"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:308
+#, c-format
+msgid "%u Channels"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:313
+#, c-format
+msgid "%u Categories, %u Channels"
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:378
+msgid "Filter Text: "
+msgstr ""
+
+#: ui/podcasts/NewChannel.cpp:378
+msgid "Enter the text to filter podcasts channels"
 msgstr ""
 
 #: ui/podcasts/ChannelEditor.cpp:39
@@ -1381,2437 +1139,6 @@ msgstr ""
 msgid "Allow delete old items"
 msgstr ""
 
-#: ui/podcasts/NewChannel.cpp:91
-msgid "New Podcast Channel"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:104
-msgid " Digital Podcast Directory "
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:115
-msgid "Search in the podcast directory"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:119
-msgid "Refresh the podcast directory list"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:236
-msgid "Filtered channels"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:311
-#, c-format
-msgid "%u Channels"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:316
-#, c-format
-msgid "%u Categories, %u Channels"
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:382
-msgid "Filter Text: "
-msgstr ""
-
-#: ui/podcasts/NewChannel.cpp:382
-msgid "Enter the text to filter podcasts channels"
-msgstr ""
-
-#: ui/itemlistbox/ItemListBox.cpp:67 ui/preferences/Preferences.cpp:1766
-#: ui/preferences/Preferences.cpp:1862
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1700
-#: ui/mediaviewer/library/AlListBox.cpp:495 ui/player/PlayerFilters.cpp:110
-#: info/smartmode/SmartMode.cpp:397
-msgid "All"
-msgstr ""
-
-#: ui/itemlistbox/ListView.cpp:1478
-msgid "Select Columns"
-msgstr ""
-
-#: ui/itemlistbox/ListView.cpp:1490
-msgid " Columns "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:133 ui/mediaviewer/treeview/TreePanel.cpp:347
-#: ui/mediaviewer/library/ArListBox.cpp:135
-#: ui/mediaviewer/library/SoListBox.cpp:465
-#: ui/mediaviewer/library/AlListBox.cpp:250
-#: ui/mediaviewer/library/AAListBox.cpp:132 ui/filebrowser/FileBrowser.cpp:329
-#: ui/filebrowser/FileBrowser.cpp:1108 ui/player/PlayList.cpp:1518
-#: ui/MainFrame.cpp:1483 ui/MainFrame.cpp:4559 misc/Accelerators.cpp:130
-#: onlinelinks/OnlineLinks.cpp:70
-msgid "Preferences"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:136 ui/preferences/Preferences.cpp:194
-#: ui/preferences/Preferences.cpp:2481
-msgid "Default"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:137
-msgid "Czech"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:138
-msgid "Danish"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:139
-msgid "Dutch"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:140 ui/preferences/Preferences.cpp:195
-msgid "English"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:141 ui/preferences/Preferences.cpp:196
-msgid "French"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:142 ui/preferences/Preferences.cpp:197
-msgid "German"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:143
-msgid "Greek"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:144
-msgid "Hungarian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:145
-msgid "Icelandic"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:146 ui/preferences/Preferences.cpp:198
-msgid "Italian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:147
-msgid "Japanese"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:148
-msgid "Lithuanian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:149
-msgid "Malay (Malaysia)"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:150
-msgid "Norwegian Bokmal"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:151
-msgid "Polish"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:152 ui/preferences/Preferences.cpp:199
-msgid "Portuguese"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:153
-msgid "Portuguese-Brazilian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:154
-msgid "Russian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:155
-msgid "Slovak"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:156 ui/preferences/Preferences.cpp:200
-msgid "Spanish"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:157
-msgid "Swedish"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:158
-msgid "Thai"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:159
-msgid "Turkish"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:160
-msgid "Ukrainian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:161
-msgid "Bulgarian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:162
-msgid "Catalan"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:163
-msgid "Serbian"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:229
-msgid "General"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:233
-msgid "Collections"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:238
-msgid "Playback"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:243
-msgid "Crossfader"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:248
-msgid "Record"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:253 ui/MainFrame.cpp:1628
-msgid "Audioscrobble"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:263
-msgid "Online"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:283 onlinelinks/OnlineLinks.cpp:73
-msgid "Links"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:288 ui/mediaviewer/treeview/TreePanel.cpp:351
-#: ui/mediaviewer/library/ArListBox.cpp:138
-#: ui/mediaviewer/library/SoListBox.cpp:468
-#: ui/mediaviewer/library/AlListBox.cpp:253
-#: ui/mediaviewer/library/AAListBox.cpp:135 ui/filebrowser/FileBrowser.cpp:332
-#: ui/filebrowser/FileBrowser.cpp:1111 ui/player/PlayList.cpp:1521
-msgid "Commands"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:293
-msgid "Copy to"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:298
-msgid "Shortcuts"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:380
-msgid " Accept "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:382
-msgid " Cancel "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:463
-msgid " On Start "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:467 ui/preferences/Preferences.cpp:1594
-msgid "Language:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:478
-msgid "(Needs restart)"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:484
-msgid "Show splash screen"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:488
-msgid "Start minimized"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:494
-msgid "Restore position for tracks longer than"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:501
-msgid "set the minimun length in minutes to save track position"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:505
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:147
-msgid "minutes"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:511
-msgid "Load default layout"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:517
-msgid " Behaviour "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:519
-msgid "Activate task bar icon"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:530
-msgid "Integrate into SoundMenu"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:536
-msgid "Enqueue as default action"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:540
-msgid "Drop files clear playlist"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:544
-msgid "Instant text search"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:548
-msgid "When searching, pressing enter queues the result"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:553
-msgid "Show CD cover frame in player"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:559
-msgid " On Close "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:561
-msgid "Save playlist on close"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:565
-msgid "Close to task bar icon"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:570
-msgid "Ask confirmation on exit"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:613
-msgid " Collections "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:661
-msgid " Paths "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:681
-msgid " Words to detect covers "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:709 ui/preferences/Preferences.cpp:2289
-msgid " Options "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:711
-msgid "Update when opened "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:715
-msgid "Create playlists on scan"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:720
-msgid "Follow symbolic links on scan"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:724
-msgid "Scan embedded covers in audio files"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:729
-msgid "Embed rating, play count and labels"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:735
-msgid "Default copy action"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:740 ui/preferences/Preferences.cpp:1769
-#: ui/preferences/Preferences.cpp:1865 ui/preferences/Preferences.cpp:1888
-#: ui/player/PlayerFilters.cpp:126 info/smartmode/SmartMode.cpp:450
-msgid "None"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:816
-msgid "Play random"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:820
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:330
-#: ui/mediaviewer/MediaViewer.cpp:1379 ui/mediaviewer/MediaViewer.cpp:1398
-#: ui/mediaviewer/MediaViewer.cpp:1413 ui/MainFrame.cpp:3330
-msgid "track"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:820
-msgid "album"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:828
-msgid "when playlist is empty"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:834
-msgid "Delete played tracks from playlist"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:838
-msgid "Show notifications"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:842
-msgid "Enable equalizer"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:846
-msgid "Enable volume and fader"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:852
-msgid "ReplayGain mode:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:856
-msgid "Disabled"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:856 ui/player/PlayList.cpp:1652
-msgid "Track"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:856
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:363
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:70
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:64
-#: ui/mediaviewer/library/SoListBox.cpp:667
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:52
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:132 ui/player/PlayList.cpp:1664
-msgid "Album"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:863
-msgid "PreAmp:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:882
-msgid " Random / Smart play modes "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:892
-msgid "Tracks left to start search"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:900
-msgid "Tracks added each time"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:909
-msgid "Max played tracks kept in playlist"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:917
-msgid "Don't repeat last"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:925
-msgid "artists or"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:933
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:330
-#: ui/mediaviewer/MediaViewer.cpp:1379 ui/mediaviewer/MediaViewer.cpp:1398
-#: ui/mediaviewer/MediaViewer.cpp:1413 ui/MainFrame.cpp:3330
-msgid "tracks"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:941
-msgid " Silence detector "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:946
-msgid "Skip at"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:965
-msgid "In the last"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:975 ui/preferences/Preferences.cpp:1209
-msgid "seconds"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:983
-msgid " Output device "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:986
-msgid "Automatic"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:987
-msgid "GConf Defined"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1037
-msgid " Crossfader "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1044
-msgid "Fade-out length:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1053
-msgid "Select the length of the fade out. 0 for gapless playback"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1056
-msgid "Fade-in length:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1065
-msgid "Select the length of the fade in"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1068
-msgid "Fade-in volume:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1077
-msgid "Select the initial volume of the fade in"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1080
-msgid "Fade-in start:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1089
-msgid "Select at which volume of the fade out the fade in starts"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1133
-msgid " Record "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1135
-msgid "Enable recording"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1141
-msgid "Save to:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1145
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:125
-msgid "Select a folder"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1152
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:694
-msgid " Properties "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1159 ui/preferences/Preferences.cpp:2310
-msgid "Format:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1171
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:817
-msgid "Quality:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1192
-msgid "Split tracks"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1199
-msgid "Delete tracks shorter than"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1242
-msgid " Last.fm audioscrobble "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1244 ui/preferences/Preferences.cpp:1280
-msgid "Enabled"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1252 ui/preferences/Preferences.cpp:1288
-#: ui/preferences/Preferences.cpp:1551
-msgid "Username:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1260 ui/preferences/Preferences.cpp:1296
-#: ui/preferences/Preferences.cpp:1560
-msgid "Password:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1278
-msgid " Libre.fm audioscrobble "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1342
-msgid " Sources "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1388
-msgid " Targets "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1430
-msgid " Disabled Genres "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1452
-msgid " Font "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1454
-msgid "Font:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1466
-msgid "Align:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1471 misc/Accelerators.cpp:351
-msgid "Left"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1472
-msgid "Center"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1473 misc/Accelerators.cpp:357
-msgid "Right"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1518
-msgid " Proxy "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1520
-msgid "Proxy Enabled"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1529
-msgid "Hostname:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1540
-msgid "Port:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1574
-msgid " Filters "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1592
-msgid " Language "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1609
-msgid " Browser command "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1617
-msgid " Minimum radio allowed bit rate "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1624
-msgid " Player online buffer size "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1661
-msgid " Podcasts "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1665
-msgid "Destination directory:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1669
-msgid "Select podcasts folder"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1677
-msgid "Check every"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1682
-msgid "Hour"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1682
-msgid "Day"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1682
-msgid "Week"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1682
-msgid "Month"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1693
-msgid "Delete after"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1702
-msgid "Days"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1702
-msgid "Weeks"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1702
-msgid "Months"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1711
-msgid "Only if played"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1772 ui/preferences/Preferences.cpp:1868
-msgid "Invert"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1786
-msgid "Audio format:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1797
-msgid "Torrent command:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1882
-msgid "Membership :"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1889
-msgid "Streaming"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1890
-msgid "Downloading"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1903
-msgid "Username :"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1911
-msgid "Password :"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1929
-msgid "Stream as :"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1943
-msgid "Download as :"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1947
-msgid "Download Page"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:1988
-msgid " Links "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2043
-msgid "URL:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2068
-msgid " Define URLs using "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2074
-msgid ""
-"2 letters language code\n"
-"Text to search"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2111
-msgid " Commands "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2164
-msgid "Command:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2189
-msgid " Define commands using "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2195
-msgid ""
-"Album path\n"
-"Album cover file path\n"
-"Track path"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2232
-msgid " Patterns "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2303 ui/filebrowser/FileRenamer.cpp:77
-msgid "Pattern:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2328
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:710
-msgid "Path:"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2344
-msgid "Remove source files"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2361
-msgid " Define patterns using "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2367
-msgid ""
-"Artist\n"
-"Album Artist\n"
-"{aa} or {a}\n"
-"Album"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2375
-msgid ""
-"Composer\n"
-"Disk\n"
-"Filename\n"
-"Genre"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2383
-msgid ""
-"Index\n"
-"Number\n"
-"Title\n"
-"Year"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2439
-msgid " Accelerators "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2444
-msgid "Action"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2448
-msgid "Key"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2890 ui/preferences/Preferences.cpp:2910
-msgid "Collection: "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:2890 ui/preferences/Preferences.cpp:2910
-msgid "Enter the collection name"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3021
-msgid "Change library path"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3043 ui/mediaviewer/MediaViewer.cpp:1157
-msgid "Select library path"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3099 ui/preferences/Preferences.cpp:3119
-msgid "Word: "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3099 ui/preferences/Preferences.cpp:3119
-msgid "Enter the text to find covers"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3441
-msgid "Genre: "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3441
-msgid "Enter the genre to disable"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3645 ui/preferences/Preferences.cpp:3675
-msgid "Filter: "
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3645
-msgid "Enter the text to filter"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:3675
-msgid "Edit the text to filter"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:4223
-msgid "Select path"
-msgstr ""
-
-#: ui/preferences/Preferences.cpp:4423
-msgid "Key used by '"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1012 ui/magnatune/Magnatune.cpp:1019
-#: ui/jamendo/Jamendo.cpp:1118 ui/jamendo/Jamendo.cpp:1128
-msgid "Download Albums"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1012 ui/magnatune/Magnatune.cpp:1019
-#: ui/jamendo/Jamendo.cpp:1118 ui/jamendo/Jamendo.cpp:1121
-#: ui/jamendo/Jamendo.cpp:1128 ui/jamendo/Jamendo.cpp:1131
-msgid "Download the current selected album"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1026
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1622
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1448
-#: ui/mediaviewer/MediaViewer.cpp:969 ui/locationpanel/LocationPanel.cpp:509
-#: ui/MainFrame.cpp:1339 ui/jamendo/Jamendo.cpp:1137
-msgid "Update the collection library"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1029
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1625
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1451
-#: ui/mediaviewer/MediaViewer.cpp:972 ui/locationpanel/LocationPanel.cpp:514
-#: ui/MainFrame.cpp:1344 ui/jamendo/Jamendo.cpp:1140
-msgid "Rescan"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1029
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1625
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1451
-#: ui/mediaviewer/MediaViewer.cpp:972 ui/locationpanel/LocationPanel.cpp:515
-#: ui/MainFrame.cpp:1345 ui/jamendo/Jamendo.cpp:1140
-msgid "Rescan the collection library"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1032
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1628
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1454
-#: ui/mediaviewer/MediaViewer.cpp:975 ui/locationpanel/LocationPanel.cpp:520
-#: ui/MainFrame.cpp:1350 ui/jamendo/Jamendo.cpp:1143
-msgid "Search Covers"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1032
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1628
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1454
-#: ui/mediaviewer/MediaViewer.cpp:975 ui/locationpanel/LocationPanel.cpp:521
-#: ui/MainFrame.cpp:1351 ui/jamendo/Jamendo.cpp:1143
-msgid "Search the collection missing covers"
-msgstr ""
-
-#: ui/magnatune/Magnatune.cpp:1037
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1638
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1464
-#: ui/mediaviewer/MediaViewer.cpp:980 ui/locationpanel/LocationPanel.cpp:536
-#: ui/MainFrame.cpp:1366 ui/jamendo/Jamendo.cpp:1148
-msgid "Show collection properties"
-msgstr ""
-
-#: ui/confirmexit/ConfirmExit.cpp:29
-msgid "Please confirm"
-msgstr ""
-
-#: ui/confirmexit/ConfirmExit.cpp:42
-msgid "Are you sure you want to exit the application?"
-msgstr ""
-
-#: ui/confirmexit/ConfirmExit.cpp:48
-msgid "Don't ask again"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:479
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1193
-msgid "embedded"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:688
-msgid "Portable Media Properties"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:719
-msgid "Used:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:730
-#, c-format
-msgid "%s free of %s"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:751
-msgid "Name Pattern:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:756
-msgid ""
-"{a}\t: Artist\t\t\t{aa} : Album Artist\n"
-"{b}\t: Album\t\t\t{d}\t : Disk\n"
-"{f}\t: Filename\t\t{g}\t : Genre\n"
-"{n}\t: Number\t\t\t{t}\t : Title\n"
-"{y}\t: Year"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:761
-msgid "Audio Folders:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:772
-msgid "Audio Formats:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:783
-msgid "Transcode to:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:804
-msgid "Unsupported formats only"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:804
-msgid "always"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:835
-msgid "Audio"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:847
-msgid "Playlist Folders:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:857
-msgid "Playlist Format:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:871
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:776
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:802
-#: ui/mediaviewer/MediaViewer.cpp:253 ui/locationpanel/LocationPanel.cpp:485
-#: ui/MainFrame.cpp:1315
-msgid "Playlists"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:881
-msgid "Cover Format:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:894
-msgid "Cover Name:"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:905
-msgid "Covers Size (pixels):"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:915
-msgid "Covers"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1026
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1121
-msgid "Select audio folder"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1095
-msgid "Audio format"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1170
-msgid "Playlist format"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1222
-msgid "Cover format"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1633
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1459
-#: ui/locationpanel/LocationPanel.cpp:529 ui/MainFrame.cpp:1359
-msgid "Unmount"
-msgstr ""
-
-#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1633
-#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1459
-#: ui/locationpanel/LocationPanel.cpp:529 ui/MainFrame.cpp:1359
-msgid "Unmount the device"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:361
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:67
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:62
-#: ui/mediaviewer/library/SoListBox.cpp:658
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:50
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:130 ui/player/PlayList.cpp:1655
-msgid "Artist"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:362
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:69
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/LibPanel.cpp:364
-#: ui/mediaviewer/library/LibPanel.cpp:371
-#: ui/mediaviewer/library/SoListBox.cpp:63
-#: ui/mediaviewer/library/SoListBox.cpp:661
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:51
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:131 ui/player/PlayList.cpp:1658
-msgid "Album Artist"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:365
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:68
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:66
-#: ui/mediaviewer/library/SoListBox.cpp:664
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:55
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:135 ui/player/PlayList.cpp:1661
-msgid "Composer"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:366
-msgid "Disk"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:368
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:428
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:71
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:69
-#: ui/mediaviewer/library/AlListBox.cpp:323
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:58
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:136 ui/player/PlayList.cpp:1667
-msgid "Year"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:616
-#: ui/mediaviewer/treeview/TreePanel.cpp:376
-#: ui/mediaviewer/library/SoListBox.cpp:495
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:285
-msgid "Edit"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:619
-#: ui/mediaviewer/library/SoListBox.cpp:498
-msgid "Edit the clicked column for the selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:625
-#: ui/mediaviewer/library/SoListBox.cpp:504
-msgid "Set"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:627
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2563
-#: ui/mediaviewer/library/SoListBox.cpp:506
-msgid "to"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:632
-#: ui/mediaviewer/library/SoListBox.cpp:511
-msgid "Set the clicked column for the selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:647
-#: ui/mediaviewer/library/PcListBox.cpp:115
-msgid "Play current selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:682
-msgid "Search again"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:683
-msgid "Search again for cd metadata"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:697
-msgid "Copy the current selected tracks to a directory or device"
-msgstr ""
-
-#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:1090
-#: ui/mediaviewer/treeview/TreePanel.cpp:1599
-#: ui/mediaviewer/library/LibPanel.cpp:1648
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1633
-msgid "Field Editor"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:303
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1725
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2556
-#: ui/mediaviewer/library/LibPanel.cpp:391
-#: ui/mediaviewer/library/LibPanel.cpp:537
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:121
-#: info/smartmode/SmartMode.cpp:467
-msgid "Tracks"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:373
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1967
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2102
-#: ui/mediaviewer/treeview/TreePanel.cpp:435
-#: ui/mediaviewer/library/ArListBox.cpp:194
-#: ui/mediaviewer/library/SoListBox.cpp:569
-#: ui/mediaviewer/library/AlListBox.cpp:303 ui/player/PlayList.cpp:1541
-#: misc/Accelerators.cpp:116
-msgid "Edit Labels"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:373
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1967
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2102
-#: ui/mediaviewer/library/AlListBox.cpp:304
-msgid "Edit the labels assigned to the selected albums"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:379
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1973
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2108
-#: ui/mediaviewer/treeview/TreePanel.cpp:445
-#: ui/mediaviewer/library/ArListBox.cpp:202
-#: ui/mediaviewer/library/SoListBox.cpp:577
-#: ui/mediaviewer/library/AlListBox.cpp:311
-#: ui/mediaviewer/library/RaListBox.cpp:191
-#: ui/mediaviewer/library/AAListBox.cpp:193
-#: ui/mediaviewer/library/YeListBox.cpp:151
-#: ui/mediaviewer/library/PcListBox.cpp:159 ui/player/PlayList.cpp:1547
-msgid "Edit Songs"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:379
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1973
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2108
-#: ui/mediaviewer/library/AlListBox.cpp:312
-msgid "Edit the selected songs"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:398
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1992
-#: ui/mediaviewer/library/AlListBox.cpp:353
-msgid "Download Cover"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:398
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1992
-#: ui/mediaviewer/library/AlListBox.cpp:353
-msgid "Download cover for the current selected album"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:402
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1996
-#: ui/mediaviewer/library/AlListBox.cpp:357
-msgid "Select Cover"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:402
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1996
-#: ui/mediaviewer/library/AlListBox.cpp:357
-msgid "Select the cover image file from disk"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:406
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2000
-#: ui/mediaviewer/library/AlListBox.cpp:361
-msgid "Delete Cover"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:406
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2000
-#: ui/mediaviewer/library/AlListBox.cpp:361
-msgid "Delete the cover for the selected album"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:413
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2007
-#: ui/mediaviewer/library/AlListBox.cpp:368
-msgid "Embed Cover"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:413
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2007
-msgid "Embed the cover to the selected album tracks"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:424
-msgid "Sort albums by name"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:428
-msgid "Sort albums by year"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:432
-#: ui/mediaviewer/library/AlListBox.cpp:324
-msgid "Year Descending"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:432
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:448
-msgid "Sort albums by year descendant"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:436
-msgid "Artist Name"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:436
-msgid "Sort albums by artist name"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:440
-#: ui/mediaviewer/library/AlListBox.cpp:326
-msgid "Artist, Year"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:440
-msgid "Sort albums by artist, year"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:444
-#: ui/mediaviewer/library/AlListBox.cpp:327
-msgid "Artist, Year Descending"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:444
-msgid "Sort albums by artist, year descendant"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:452
-#: ui/mediaviewer/library/AlListBox.cpp:332
-msgid "Sort By"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:452
-msgid "Set the albums sorting"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:917 misc/Accelerators.cpp:306
-msgid "Back"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1468
-#: ui/mediaviewer/treeview/TreePanel.cpp:1059
-#: ui/mediaviewer/library/LibPanel.cpp:1149
-msgid "Albums Labels Editor"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1767
-msgid "Page"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2121
-#: ui/mediaviewer/library/SoListBox.cpp:631 ui/player/PlayList.cpp:1605
-msgid "Create Smart Playlist"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2121
-#: ui/mediaviewer/library/SoListBox.cpp:631 ui/player/PlayList.cpp:1605
-msgid "Create a smart playlist from this track"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2186
-#: ui/mediaviewer/treeview/TreePanel.cpp:1323
-#: ui/mediaviewer/library/LibPanel.cpp:1367
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1355 ui/player/PlayList.cpp:2164
-msgid "Tracks Labels Editor"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2513
-#: ui/mediaviewer/treeview/TreePanel.cpp:1158
-#: ui/mediaviewer/treeview/TreePanel.cpp:1430
-#: ui/mediaviewer/library/LibPanel.cpp:1440
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1464
-#: ui/filebrowser/FileBrowser.cpp:1969 ui/filebrowser/FileBrowser.cpp:2113
-#: ui/player/PlayList.cpp:1998
-msgid "UnNamed"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2562
-#: ui/mediaviewer/library/LibPanel.cpp:268
-#: ui/mediaviewer/library/LibPanel.cpp:275
-#: ui/mediaviewer/library/LibPanel.cpp:525
-#: ui/locationpanel/LocationPanel.cpp:445 ui/MainFrame.cpp:1275
-msgid "Albums"
-msgstr ""
-
-#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2564
-msgid "of"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:75
-msgid "Genres,Artists,Albums"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:76
-msgid "Genres,Year,Artists,Albums"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:91
-msgid "Sortings"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:92
-#: ui/locationpanel/LocationPanel.cpp:465
-#: ui/locationpanel/LocationPanel.cpp:469 ui/MainFrame.cpp:1295
-#: ui/MainFrame.cpp:1299
-msgid "Library"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:347
-#: ui/mediaviewer/library/ArListBox.cpp:135
-#: ui/mediaviewer/library/SoListBox.cpp:465
-#: ui/mediaviewer/library/AlListBox.cpp:250
-#: ui/mediaviewer/library/AAListBox.cpp:132 ui/filebrowser/FileBrowser.cpp:329
-#: ui/filebrowser/FileBrowser.cpp:1108 ui/player/PlayList.cpp:1518
-msgid "Add commands in preferences"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:372
-#: ui/mediaviewer/library/TaListBox.cpp:107
-msgid "Create"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:372
-msgid "Create a new filter"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:376
-msgid "Edit the selected filter"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:380
-msgid "Delete the selected filter"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:399
-#: ui/mediaviewer/library/SoListBox.cpp:534
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:233
-msgid "Add current selected songs to the playlist"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:436
-msgid "Edit the labels assigned to the selected items"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:446
-#: ui/mediaviewer/library/CoListBox.cpp:152
-#: ui/mediaviewer/library/RaListBox.cpp:192
-#: ui/mediaviewer/library/AAListBox.cpp:194
-#: ui/mediaviewer/library/YeListBox.cpp:152
-#: ui/mediaviewer/library/PcListBox.cpp:160
-msgid "Edit the selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:833
-#: ui/mediaviewer/treeview/TreePanel.cpp:858
-#: ui/locationpanel/LocationPanel.cpp:480 ui/MainFrame.cpp:1310
-msgid "Tree"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:1059
-#: ui/mediaviewer/library/LibPanel.cpp:951
-msgid "Artist Labels Editor"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:1189
-#: ui/mediaviewer/MediaViewer.cpp:853
-msgid "New Filter"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreePanel.cpp:1231
-msgid "Are you sure to delete the selected filter?"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:36
-msgid "Filter Editor"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:57 ui/MainFrame.cpp:255
-#: ui/MainFrame.cpp:354
-msgid "Filters"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:65
-#: ui/mediaviewer/library/LibPanel.cpp:233
-#: ui/mediaviewer/library/LibPanel.cpp:240
-#: ui/mediaviewer/library/LibPanel.cpp:521
-#: ui/locationpanel/LocationPanel.cpp:420 ui/MainFrame.cpp:1250
-msgid "Labels"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:72
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-#: ui/mediaviewer/library/SoListBox.cpp:71
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:59
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:137 ui/taskbar/TaskBar.cpp:166
-#: ui/player/PlayList.cpp:1576 misc/Accelerators.cpp:134
-#: misc/Accelerators.cpp:135 misc/Accelerators.cpp:136
-#: misc/Accelerators.cpp:137 misc/Accelerators.cpp:138
-#: misc/Accelerators.cpp:139
-msgid "Rating"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:73
-msgid "Play Count"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:122
-msgid "Filter:"
-msgstr ""
-
-#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:126
-msgid "PlayCount"
-msgstr ""
-
-#: ui/mediaviewer/library/CoListBox.cpp:107
-msgid "Play current selected composer"
-msgstr ""
-
-#: ui/mediaviewer/library/CoListBox.cpp:114
-#: ui/mediaviewer/library/RaListBox.cpp:154
-#: ui/mediaviewer/library/AAListBox.cpp:156
-#: ui/mediaviewer/library/YeListBox.cpp:114
-#: ui/mediaviewer/library/PcListBox.cpp:122
-msgid "Add current selected tracks to playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/CoListBox.cpp:123
-#: ui/mediaviewer/library/CoListBox.cpp:130
-#: ui/mediaviewer/library/CoListBox.cpp:137
-#: ui/mediaviewer/library/AlListBox.cpp:282
-#: ui/mediaviewer/library/AlListBox.cpp:288
-#: ui/mediaviewer/library/AlListBox.cpp:294
-msgid "Add current selected albums to the Playlist as Next Tracks"
-msgstr ""
-
-#: ui/mediaviewer/library/CoListBox.cpp:142
-#: ui/mediaviewer/library/AlListBox.cpp:298
-msgid "Add the selected albums after"
-msgstr ""
-
-#: ui/mediaviewer/library/CoListBox.cpp:151
-msgid "Edit songs"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:251
-#: ui/mediaviewer/library/LibPanel.cpp:258
-#: ui/mediaviewer/library/LibPanel.cpp:523
-#: ui/locationpanel/LocationPanel.cpp:430 ui/MainFrame.cpp:1260
-msgid "Artists"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:288
-#: ui/mediaviewer/library/LibPanel.cpp:295
-#: ui/mediaviewer/library/LibPanel.cpp:527
-#: ui/locationpanel/LocationPanel.cpp:450 ui/MainFrame.cpp:1280
-msgid "Years"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:307
-#: ui/mediaviewer/library/LibPanel.cpp:314
-#: ui/mediaviewer/library/LibPanel.cpp:529
-#: ui/locationpanel/LocationPanel.cpp:455 ui/MainFrame.cpp:1285
-msgid "Ratings"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:345
-#: ui/mediaviewer/library/LibPanel.cpp:352
-#: ui/mediaviewer/library/LibPanel.cpp:533
-#: ui/locationpanel/LocationPanel.cpp:435 ui/MainFrame.cpp:1265
-msgid "Composers"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:535
-#: ui/locationpanel/LocationPanel.cpp:440 ui/MainFrame.cpp:1270
-msgid "Album Artists"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:1226
-msgid "Are you sure to delete the selected album cover?"
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:2786
-msgid ""
-"Are you sure to delete the selected tracks from your drive?\n"
-"This will permanently erase the selected tracks."
-msgstr ""
-
-#: ui/mediaviewer/library/LibPanel.cpp:2787
-msgid "Remove tracks from drive"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:152
-#: ui/mediaviewer/library/YeListBox.cpp:107
-msgid "Play current selected artists"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:159
-msgid "Add current selected artists to playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:195
-msgid "Edit the labels assigned to the selected artists"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:203
-msgid "Edit the songs from the selected artists"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:217
-#: ui/mediaviewer/library/AlListBox.cpp:345
-#: ui/mediaviewer/library/AAListBox.cpp:208
-msgid "Create Best of Playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/ArListBox.cpp:218
-msgid "Create a playlist with the best of this aretist"
-msgstr ""
-
-#: ui/mediaviewer/library/GeListBox.cpp:96
-msgid "Play current selected genres"
-msgstr ""
-
-#: ui/mediaviewer/library/GeListBox.cpp:103
-msgid "Add current selected genres to playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:67
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:67
-msgid "Disc"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:70
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:65
-msgid "Bit Rate"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:76
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:57
-msgid "Path"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:77
-msgid "Offset"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:570
-msgid "Edit the labels assigned to the selected songs"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:578
-msgid "Edit the songs selected"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:590 ui/taskbar/TaskBar.cpp:147
-#: ui/player/PlayList.cpp:1563 ui/MainFrame.cpp:1553
-msgid "Set the rating to 0"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:595 ui/taskbar/TaskBar.cpp:150
-#: ui/player/PlayList.cpp:1565 ui/MainFrame.cpp:1558
-msgid "Set the rating to 1"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:600 ui/taskbar/TaskBar.cpp:153
-#: ui/player/PlayList.cpp:1567 ui/MainFrame.cpp:1563
-msgid "Set the rating to 2"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:605 ui/taskbar/TaskBar.cpp:156
-#: ui/player/PlayList.cpp:1569 ui/MainFrame.cpp:1568
-msgid "Set the rating to 3"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:610 ui/taskbar/TaskBar.cpp:159
-#: ui/player/PlayList.cpp:1571 ui/MainFrame.cpp:1573
-msgid "Set the rating to 4"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:615 ui/taskbar/TaskBar.cpp:162
-#: ui/player/PlayList.cpp:1573 ui/MainFrame.cpp:1578
-msgid "Set the rating to 5"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:618 ui/MainFrame.cpp:1581
-msgid "Set Rating"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:618 ui/taskbar/TaskBar.cpp:166
-msgid "Set the current track rating"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:625
-msgid "Save all selected tracks as a playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:633 ui/player/PlayList.cpp:1607
-msgid "Create Best Of Playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:633
-#: ui/mediaviewer/library/AlListBox.cpp:346
-#: ui/mediaviewer/library/AAListBox.cpp:209 ui/player/PlayList.cpp:1607
-msgid "Create a playlist with the best of this artist"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:641 ui/player/PlayList.cpp:1633
-msgid "Remove from Library"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:641
-msgid "Remove the current selected tracks from library"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:646 ui/player/PlayList.cpp:1639
-msgid "Delete from Drive"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:646
-msgid "Remove the current selected tracks from drive"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:655
-msgid "Selects the genre of the current song"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:658 ui/player/PlayList.cpp:1655
-msgid "Selects the artist of the current song"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:661
-msgid "Selects the album artist of the current song"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:664
-msgid "Selects the composer of the current song"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:667 ui/player/PlayList.cpp:1664
-msgid "Select the album of the current song"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:670 ui/player/PlayList.cpp:1673
-#: misc/Accelerators.cpp:409
-msgid "Select"
-msgstr ""
-
-#: ui/mediaviewer/library/SoListBox.cpp:670 ui/player/PlayList.cpp:1673
-msgid "Search in the library"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:181
-msgid "by "
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:268
-msgid "Play current selected albums"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:274
-msgid "Add current selected albums to the Playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:322
-msgid "Albums are sorted by name"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:323
-msgid "Albums are sorted by year"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:324
-msgid "Albums are sorted by year descending"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:325
-msgid "Artist, Name"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:325
-msgid "Albums are sorted by artist and album name"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:326
-msgid "Albums are sorted by artist and year"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:327
-msgid "Albums are sorted by artist and year descending"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:332
-msgid "Sets the albums order"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:340
-#: ui/mediaviewer/library/AAListBox.cpp:203
-#: ui/mediaviewer/library/YeListBox.cpp:161
-msgid "Save the selected tracks to Playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/AlListBox.cpp:368
-msgid "Embed the current cover to the album files"
-msgstr ""
-
-#: ui/mediaviewer/library/RaListBox.cpp:147
-msgid "Play the selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:107
-msgid "Create a new label"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:114
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:294
-#: ui/filebrowser/FileBrowser.cpp:431
-msgid "Rename"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:114
-msgid "Change selected label"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:118
-msgid "Delete selected labels"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:127
-msgid "Play current selected labels"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:134
-msgid "Add current selected labels to playlist"
-msgstr ""
-
-#: ui/mediaviewer/library/TaListBox.cpp:230
-msgid "Enter the new label name"
-msgstr ""
-
-#: ui/mediaviewer/library/AAListBox.cpp:149
-msgid "Play current selected album artist"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:51
-#: ui/mediaviewer/MediaViewer.cpp:963 ui/locationpanel/LocationPanel.cpp:500
-#: ui/MainFrame.cpp:1330
-msgid "Import Files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:93
-msgid "Copy to Option:"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:121
-msgid "Destination Folder:"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:131
-msgid " Files "
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:243
-msgid "Select files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:244
-msgid "Audio files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:245
-msgid "mp3 files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:246
-msgid "ogg files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:247
-msgid "flac files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:248
-msgid "mp4 files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:249
-msgid "wma files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:250
-msgid "ape files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:251
-msgid "waf files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:252
-msgid "aif files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:253
-msgid "wv files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:254
-msgid "tta files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:255
-msgid "mpc files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:256
-msgid "other files"
-msgstr ""
-
-#: ui/mediaviewer/importfiles/ImportFiles.cpp:340
-msgid "No files added"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:86
-msgid "Static playlists"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:87
-msgid "Dynamic playlists"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:263
-msgid "New Dynamic Playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:263
-msgid "Create a new dynamic playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:269
-msgid "Import a playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:275
-msgid "Export the playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:285
-msgid "Edit the selected playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:289
-msgid "Save the selected playlist as a Static Playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:294
-msgid "Change the name of the selected playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:299
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:309
-msgid "Delete the selected playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:305
-msgid "Set as Allow Filter"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:305
-msgid "Set this playlist as the allow filter"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:309
-msgid "Set as Deny Filter"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1041
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1182
-msgid "Playlist Name: "
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1042
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1183
-msgid "Enter the new playlist name"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1082
-msgid "Are you sure to delete the selected Playlist?"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1167
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1242
-msgid "Select the playlist file"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListPanel.cpp:1194
-msgid "New Playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PLSoListBox.cpp:164 ui/player/PlayList.cpp:1612
-#: misc/Accelerators.cpp:133
-msgid "Randomize Playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PLSoListBox.cpp:165 ui/player/PlayList.cpp:1613
-msgid "Randomize the songs in the playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PLSoListBox.cpp:172 ui/player/PlayList.cpp:1625
-msgid "Remove from Playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PLSoListBox.cpp:172
-msgid "Delete the current selected tracks"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:52
-msgid "Playlist:"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:64
-msgid "New playlist"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:68
-msgid "Where:"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:72
-msgid "Beginning"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:72 misc/Accelerators.cpp:378
-msgid "End"
-msgstr ""
-
-#: ui/mediaviewer/playlists/PlayListAppend.cpp:78
-msgid "Tracks:"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:54
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:134
-msgid "Label"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:56
-msgid "Comment"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:64
-msgid "Track Number"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:66
-#: ui/filebrowser/FileBrowser.cpp:776
-msgid "Size"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:68
-msgid "Has Cover"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:73
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:83
-msgid "contains"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:74
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:84
-msgid "does not contain"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:75
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:85
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:94
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:102
-msgid "is"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:76
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:86
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:95
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:103
-msgid "is not"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:77
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:87
-msgid "begins with"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:78
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:88
-msgid "ends with"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:89
-msgid "not set"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:96
-msgid "at least"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:97
-msgid "at most"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:104
-msgid "after"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:105
-msgid "before"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:110
-msgid "in the last"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:111
-msgid "before the last"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:116
-msgid "false"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:117
-msgid "true"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:122
-#: info/smartmode/SmartMode.cpp:468
-msgid "Minutes"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:142
-msgid "Random"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:148
-msgid "hours"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:149
-msgid "days"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:150
-msgid "weeks"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:151
-msgid "months"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:442
-msgid "Filter Album Browser"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:443
-msgid "Dynamic Playlist Editor"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:471
-msgid " Current Filters "
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:552
-msgid " Result "
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:557
-#: info/smartmode/SmartMode.cpp:456
-msgid "Limit to"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:577
-msgid "Any filter selects tracks"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:588
-msgid "Sort by"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:598
-msgid "Descending"
-msgstr ""
-
-#: ui/mediaviewer/playlists/DynamicPlayList.cpp:616
-msgid "Add tracks on any criteria"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:232
-msgid "All Albums"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:241
-msgid "Library view"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:245
-msgid "Album Browser view"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:249
-msgid "Tree view"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:265
-msgid "View the current defined filters"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:270
-msgid "Add a new album browser filter"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:274
-msgid "Delete the current selected filter"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:279
-msgid "Edit the current selected filter"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:960 ui/locationpanel/LocationPanel.cpp:496
-#: ui/MainFrame.cpp:1326
-msgid "Add Path"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:960 ui/locationpanel/LocationPanel.cpp:496
-#: ui/MainFrame.cpp:1326
-msgid "Add path to the collection"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:963 ui/locationpanel/LocationPanel.cpp:500
-#: ui/MainFrame.cpp:1330
-msgid "Import files into the collection"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:984
-msgid "Collection"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:1187
-msgid "This Path is already in the library"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:1188
-msgid "Adding path error"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:2172
-msgid " smart playlist"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:2181
-msgid "Playlist"
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:2215
-msgid "The best of "
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:2241
-#, c-format
-msgid "No tracks found for %s."
-msgstr ""
-
-#: ui/mediaviewer/MediaViewer.cpp:2246
-#, c-format
-msgid "Best tracks for '%s' not found."
-msgstr ""
-
-#: ui/filebrowser/FileRenamer.cpp:50 ui/filebrowser/FileBrowser.cpp:1202
-msgid "Rename Files"
-msgstr ""
-
-#: ui/filebrowser/FileRenamer.cpp:58
-msgid " Names Preview "
-msgstr ""
-
-#: ui/filebrowser/FileRenamer.cpp:85
-msgid ""
-"Pattern flags:\n"
-"{g} : Genre\n"
-"{a} : Artist\n"
-"{aa}: Album Artist\n"
-"{A} : {aa} or {a}\n"
-"{b} : Album\n"
-"{t} : Title\n"
-"{n} : Number\n"
-"{y} : Year\n"
-"{d} : Disk"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:231 ui/filebrowser/FileBrowser.cpp:600
-msgid "See used locations"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:232 ui/filebrowser/FileBrowser.cpp:601
-msgid "See system files"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:345
-msgid "Play the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:351
-msgid "Add the selected folder to playlist"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:380 ui/filebrowser/FileBrowser.cpp:1165
-#: misc/Accelerators.cpp:117
-msgid "Edit Tracks"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:381
-msgid "Edit the tracks in the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:389
-msgid "Add the tracks in the selected folder to a playlist"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:396 ui/filebrowser/FileBrowser.cpp:1181
-msgid "Copy"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:397 ui/filebrowser/FileBrowser.cpp:1181
-msgid "Copy the selected folder to clipboard"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:404
-msgid "Paste to the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:421
-msgid "Update the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:428 ui/filebrowser/FileBrowser.cpp:485
-#: ui/filebrowser/FileBrowser.cpp:489
-msgid "New Folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:428
-msgid "Create a new folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:431
-msgid "Rename the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:435 ui/filebrowser/FileBrowser.cpp:1206
-msgid "Remove"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:435
-msgid "Remove the selected folder"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:566
-msgid "Are you sure to delete the selected path ?"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:577
-msgid "Error deleting the folder "
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:777
-msgid "Modified"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1124
-msgid "Play current selected files"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1130
-msgid "Add current selected files to playlist"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1166
-msgid "Edit the current selected files"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1174
-msgid "Add the current selected tracks to a playlist"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1185
-msgid "Paste to the selected dir"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1202
-msgid "Rename the current selected file"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1206
-msgid "Delete the selected files"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:1548 ui/filebrowser/FileBrowser.cpp:1564
-msgid "Directories"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:2216
-msgid "Are you sure to delete the selected files ?"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:2234
-msgid "There was an error deleting "
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:2235
-msgid ""
-"\n"
-"Continue deleting?"
-msgstr ""
-
-#: ui/filebrowser/FileBrowser.cpp:2236
-msgid "Continue"
-msgstr ""
-
-#: ui/statusbar/StatusBar.cpp:157 ui/statusbar/StatusBar.cpp:217
-msgid "Enable audioscrobbling"
-msgstr ""
-
-#: ui/statusbar/StatusBar.cpp:160
-msgid "Shows information about the selected items"
-msgstr ""
-
-#: ui/statusbar/StatusBar.cpp:217
-msgid "Disable audioscrobbling"
-msgstr ""
-
 #: ui/locationpanel/LocationPanel.cpp:98
 msgid "Local Music"
 msgstr ""
@@ -3836,6 +1163,11 @@ msgstr ""
 #: ui/locationpanel/LocationPanel.cpp:278 ui/MainFrame.cpp:1026
 #: ui/MainFrame.cpp:2866
 msgid "File Browser"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:290 ui/preferences/Preferences.cpp:257
+#: ui/MainFrame.cpp:1444 ui/MainFrame.cpp:2800 ui/trackedit/TrackEdit.cpp:414
+msgid "Lyrics"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:311
@@ -3893,6 +1225,14 @@ msgid "View the collection library"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:420 ui/MainFrame.cpp:1250
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:65
+#: ui/mediaviewer/library/LibPanel.cpp:233
+#: ui/mediaviewer/library/LibPanel.cpp:240
+#: ui/mediaviewer/library/LibPanel.cpp:521
+msgid "Labels"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:420 ui/MainFrame.cpp:1250
 msgid "View the library labels"
 msgstr ""
 
@@ -3901,7 +1241,21 @@ msgid "View the library genres"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:430 ui/MainFrame.cpp:1260
+#: ui/mediaviewer/library/LibPanel.cpp:251
+#: ui/mediaviewer/library/LibPanel.cpp:258
+#: ui/mediaviewer/library/LibPanel.cpp:523
+msgid "Artists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:430 ui/MainFrame.cpp:1260
 msgid "View the library artists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:435 ui/MainFrame.cpp:1265
+#: ui/mediaviewer/library/LibPanel.cpp:345
+#: ui/mediaviewer/library/LibPanel.cpp:352
+#: ui/mediaviewer/library/LibPanel.cpp:533
+msgid "Composers"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:435 ui/MainFrame.cpp:1265
@@ -3909,7 +1263,20 @@ msgid "View the library composers"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:440 ui/MainFrame.cpp:1270
+#: ui/mediaviewer/library/LibPanel.cpp:535
+msgid "Album Artists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:440 ui/MainFrame.cpp:1270
 msgid "View the library album artists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:445 ui/MainFrame.cpp:1275
+#: ui/mediaviewer/library/LibPanel.cpp:268
+#: ui/mediaviewer/library/LibPanel.cpp:275
+#: ui/mediaviewer/library/LibPanel.cpp:525
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2562
+msgid "Albums"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:445 ui/MainFrame.cpp:1275
@@ -3917,7 +1284,21 @@ msgid "View the library albums"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:450 ui/MainFrame.cpp:1280
+#: ui/mediaviewer/library/LibPanel.cpp:288
+#: ui/mediaviewer/library/LibPanel.cpp:295
+#: ui/mediaviewer/library/LibPanel.cpp:527
+msgid "Years"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:450 ui/MainFrame.cpp:1280
 msgid "View the library years"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:455 ui/MainFrame.cpp:1285
+#: ui/mediaviewer/library/LibPanel.cpp:307
+#: ui/mediaviewer/library/LibPanel.cpp:314
+#: ui/mediaviewer/library/LibPanel.cpp:529
+msgid "Ratings"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:455 ui/MainFrame.cpp:1285
@@ -3932,6 +1313,12 @@ msgstr ""
 msgid "View the library play counts"
 msgstr ""
 
+#: ui/locationpanel/LocationPanel.cpp:465
+#: ui/locationpanel/LocationPanel.cpp:469 ui/MainFrame.cpp:1295
+#: ui/MainFrame.cpp:1299 ui/mediaviewer/treeview/TreePanel.cpp:92
+msgid "Library"
+msgstr ""
+
 #: ui/locationpanel/LocationPanel.cpp:475 ui/MainFrame.cpp:1305
 msgid "Album Browser"
 msgstr ""
@@ -3941,11 +1328,58 @@ msgid "View the collection album browser"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:480 ui/MainFrame.cpp:1310
+#: ui/mediaviewer/treeview/TreePanel.cpp:824
+#: ui/mediaviewer/treeview/TreePanel.cpp:849
+msgid "Tree"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:480 ui/MainFrame.cpp:1310
 msgid "View the collection tree view"
 msgstr ""
 
 #: ui/locationpanel/LocationPanel.cpp:485 ui/MainFrame.cpp:1315
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:867
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:768
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:794
+#: ui/mediaviewer/MediaViewer.cpp:253
+msgid "Playlists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:485 ui/MainFrame.cpp:1315
 msgid "View the collection playlists"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:496 ui/MainFrame.cpp:1326
+#: ui/mediaviewer/MediaViewer.cpp:960
+msgid "Add Path"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:496 ui/MainFrame.cpp:1326
+#: ui/mediaviewer/MediaViewer.cpp:960
+msgid "Add path to the collection"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:500 ui/MainFrame.cpp:1330
+#: ui/mediaviewer/MediaViewer.cpp:963
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:51
+msgid "Import Files"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:500 ui/MainFrame.cpp:1330
+#: ui/mediaviewer/MediaViewer.cpp:963
+msgid "Import files into the collection"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:529 ui/MainFrame.cpp:1359
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1623
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1459
+msgid "Unmount"
+msgstr ""
+
+#: ui/locationpanel/LocationPanel.cpp:529 ui/MainFrame.cpp:1359
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1623
+#: ui/mediaviewer/ipodmedia/iPodMedia.cpp:1459
+msgid "Unmount the device"
 msgstr ""
 
 #: ui/taskbar/TaskBar.cpp:116
@@ -3990,6 +1424,52 @@ msgstr ""
 
 #: ui/taskbar/TaskBar.cpp:138
 msgid "Skip to previous album track in current playlist"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:147 ui/MainFrame.cpp:1553 ui/player/PlayList.cpp:1547
+#: ui/mediaviewer/library/SoListBox.cpp:587
+msgid "Set the rating to 0"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:150 ui/MainFrame.cpp:1558 ui/player/PlayList.cpp:1549
+#: ui/mediaviewer/library/SoListBox.cpp:592
+msgid "Set the rating to 1"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:153 ui/MainFrame.cpp:1563 ui/player/PlayList.cpp:1551
+#: ui/mediaviewer/library/SoListBox.cpp:597
+msgid "Set the rating to 2"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:156 ui/MainFrame.cpp:1568 ui/player/PlayList.cpp:1553
+#: ui/mediaviewer/library/SoListBox.cpp:602
+msgid "Set the rating to 3"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:159 ui/MainFrame.cpp:1573 ui/player/PlayList.cpp:1555
+#: ui/mediaviewer/library/SoListBox.cpp:607
+msgid "Set the rating to 4"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:162 ui/MainFrame.cpp:1578 ui/player/PlayList.cpp:1557
+#: ui/mediaviewer/library/SoListBox.cpp:612
+msgid "Set the rating to 5"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:166 ui/player/PlayList.cpp:1560
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:59
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:137
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:72
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/SoListBox.cpp:71 misc/Accelerators.cpp:134
+#: misc/Accelerators.cpp:135 misc/Accelerators.cpp:136
+#: misc/Accelerators.cpp:137 misc/Accelerators.cpp:138
+#: misc/Accelerators.cpp:139
+msgid "Rating"
+msgstr ""
+
+#: ui/taskbar/TaskBar.cpp:166 ui/mediaviewer/library/SoListBox.cpp:615
+msgid "Set the current track rating"
 msgstr ""
 
 #: ui/taskbar/TaskBar.cpp:169
@@ -4048,206 +1528,882 @@ msgstr ""
 msgid "Exit this program"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:176
-msgid "Go to the playlist previous track"
+#: ui/preferences/Preferences.cpp:132 ui/MainFrame.cpp:1483
+#: ui/MainFrame.cpp:4559 ui/filebrowser/FileBrowser.cpp:329
+#: ui/filebrowser/FileBrowser.cpp:1108 ui/player/PlayList.cpp:1502
+#: ui/mediaviewer/treeview/TreePanel.cpp:343
+#: ui/mediaviewer/library/AlListBox.cpp:249
+#: ui/mediaviewer/library/ArListBox.cpp:134
+#: ui/mediaviewer/library/AAListBox.cpp:131
+#: ui/mediaviewer/library/SoListBox.cpp:462 onlinelinks/OnlineLinks.cpp:70
+#: misc/Accelerators.cpp:130
+msgid "Preferences"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:181
-msgid "Play or pause the current track"
+#: ui/preferences/Preferences.cpp:135 ui/preferences/Preferences.cpp:193
+#: ui/preferences/Preferences.cpp:2473
+msgid "Default"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:186
-msgid "Go to the playlist next track"
+#: ui/preferences/Preferences.cpp:136
+msgid "Czech"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:190
-msgid "Stops the current track"
+#: ui/preferences/Preferences.cpp:137
+msgid "Danish"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:194
-msgid "Record to file"
+#: ui/preferences/Preferences.cpp:138
+msgid "Dutch"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:207
-msgid "Randomize the tracks in playlist"
+#: ui/preferences/Preferences.cpp:139 ui/preferences/Preferences.cpp:194
+msgid "English"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:213 ui/player/PlayerPanel.cpp:3289
-msgid "Enable crossfading"
+#: ui/preferences/Preferences.cpp:140 ui/preferences/Preferences.cpp:195
+msgid "French"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:213 ui/player/PlayerPanel.cpp:3289
-msgid "Disable crossfading"
+#: ui/preferences/Preferences.cpp:141 ui/preferences/Preferences.cpp:196
+msgid "German"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:223
-msgid "Show the equalizer (right click for on/off)"
+#: ui/preferences/Preferences.cpp:142
+msgid "Greek"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:227 ui/player/PlayerPanel.cpp:2955
-msgid "Volume"
+#: ui/preferences/Preferences.cpp:143
+msgid "Hungarian"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:256
-msgid "Show the name of the current track"
+#: ui/preferences/Preferences.cpp:144
+msgid "Icelandic"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:265
-msgid "Show the album name of the current track"
+#: ui/preferences/Preferences.cpp:145 ui/preferences/Preferences.cpp:197
+msgid "Italian"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:276
-msgid "Show the artist name of the current track"
+#: ui/preferences/Preferences.cpp:146
+msgid "Japanese"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:286
-msgid "Show the year of the current track"
+#: ui/preferences/Preferences.cpp:147
+msgid "Lithuanian"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:289
-msgid "00:00 of 00:00"
+#: ui/preferences/Preferences.cpp:148
+msgid "Malay (Malaysia)"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:290
-msgid "Show the current position and song length of the current track"
+#: ui/preferences/Preferences.cpp:149
+msgid "Norwegian Bokmal"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:309
-msgid "Show the file format of the current track"
+#: ui/preferences/Preferences.cpp:150
+msgid "Polish"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:316
-msgid "Show the bit rate of the current track"
+#: ui/preferences/Preferences.cpp:151 ui/preferences/Preferences.cpp:198
+msgid "Portuguese"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:1407
-msgid "Buffering..."
+#: ui/preferences/Preferences.cpp:152
+msgid "Portuguese-Brazilian"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:1495 ui/jamendo/Jamendo.cpp:645
-#: db/DbLibrary.cpp:288 db/DbLibrary.cpp:300 db/DbLibrary.cpp:1771
-#: db/DbLibrary.cpp:1783 db/DbLibrary.cpp:1856 db/DbLibrary.cpp:1868
-msgid "Unknown"
+#: ui/preferences/Preferences.cpp:153
+msgid "Russian"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:2692
-msgid "Smart mode enabled"
+#: ui/preferences/Preferences.cpp:154
+msgid "Slovak"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:2698
-msgid "Repeat all"
+#: ui/preferences/Preferences.cpp:155 ui/preferences/Preferences.cpp:199
+msgid "Spanish"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:2703
-msgid "Repeat one"
+#: ui/preferences/Preferences.cpp:156
+msgid "Swedish"
 msgstr ""
 
-#: ui/player/PlayerPanel.cpp:2710
-msgid "Smart mode disabled"
+#: ui/preferences/Preferences.cpp:157
+msgid "Thai"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1532
-msgid "Empty Playlist"
+#: ui/preferences/Preferences.cpp:158
+msgid "Turkish"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1532
-msgid "The playlist is empty"
+#: ui/preferences/Preferences.cpp:159
+msgid "Ukrainian"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1542
-msgid "Edit the current selected tracks labels"
+#: ui/preferences/Preferences.cpp:160
+msgid "Bulgarian"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1548
-msgid "Edit the current selected songs"
+#: ui/preferences/Preferences.cpp:161
+msgid "Catalan"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1557
-msgid "Set as Next Track"
+#: ui/preferences/Preferences.cpp:162
+msgid "Serbian"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1558
-msgid "Move the selected tracks to be played next"
+#: ui/preferences/Preferences.cpp:228
+msgid "General"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1576
-msgid "Set the current selected tracks rating"
+#: ui/preferences/Preferences.cpp:232
+msgid "Collections"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1582 misc/Accelerators.cpp:145
-msgid "Search"
+#: ui/preferences/Preferences.cpp:237
+msgid "Playback"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1583
-msgid "Search a track in the playlist by name"
+#: ui/preferences/Preferences.cpp:242
+msgid "Crossfader"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1617 ui/MainFrame.cpp:1542 misc/Accelerators.cpp:113
-msgid "Clear Playlist"
+#: ui/preferences/Preferences.cpp:247
+msgid "Record"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1618
-msgid "Remove all tracks from playlist"
+#: ui/preferences/Preferences.cpp:252 ui/MainFrame.cpp:1628
+msgid "Audioscrobble"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1626
-msgid "Remove the selected tracks from playlist"
+#: ui/preferences/Preferences.cpp:262
+msgid "Online"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1634
-msgid "Remove the selected tracks from library"
+#: ui/preferences/Preferences.cpp:282 onlinelinks/OnlineLinks.cpp:73
+msgid "Links"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1640
-msgid "Remove the selected tracks from drive"
+#: ui/preferences/Preferences.cpp:287 ui/filebrowser/FileBrowser.cpp:332
+#: ui/filebrowser/FileBrowser.cpp:1111 ui/player/PlayList.cpp:1505
+#: ui/mediaviewer/treeview/TreePanel.cpp:347
+#: ui/mediaviewer/library/AlListBox.cpp:252
+#: ui/mediaviewer/library/ArListBox.cpp:137
+#: ui/mediaviewer/library/AAListBox.cpp:134
+#: ui/mediaviewer/library/SoListBox.cpp:465
+msgid "Commands"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1652
-msgid "Selects the current selected track in the library"
+#: ui/preferences/Preferences.cpp:292
+msgid "Copy to"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1658
-msgid "Select the album artist of the current song"
+#: ui/preferences/Preferences.cpp:297
+msgid "Shortcuts"
 msgstr ""
 
-#: ui/player/PlayList.cpp:1661
-msgid "Select the composer of the current song"
+#: ui/preferences/Preferences.cpp:379
+msgid " Accept "
 msgstr ""
 
-#: ui/player/PlayList.cpp:1667
-msgid "Select the year of the current song"
+#: ui/preferences/Preferences.cpp:381
+msgid " Cancel "
 msgstr ""
 
-#: ui/player/PlayList.cpp:1670
-msgid "Select the genre of the current song"
+#: ui/preferences/Preferences.cpp:462
+msgid " On Start "
 msgstr ""
 
-#: ui/player/PlayList.cpp:2038
-msgid "Can't create a playlist without mediaviewer."
+#: ui/preferences/Preferences.cpp:466 ui/preferences/Preferences.cpp:1591
+msgid "Language:"
 msgstr ""
 
-#: ui/player/PlayList.cpp:2194
-msgid "Search: "
+#: ui/preferences/Preferences.cpp:477
+msgid "(Needs restart)"
 msgstr ""
 
-#: ui/player/PlayList.cpp:2194
-msgid "Please enter the search term"
+#: ui/preferences/Preferences.cpp:483
+msgid "Show splash screen"
 msgstr ""
 
-#: ui/player/PlayList.cpp:2780
-msgid "Loading tracks. Please wait"
+#: ui/preferences/Preferences.cpp:487
+msgid "Start minimized"
 msgstr ""
 
-#: ui/player/PlayerFilters.cpp:45
-msgid "Allow:"
+#: ui/preferences/Preferences.cpp:493
+msgid "Restore position for tracks longer than"
 msgstr ""
 
-#: ui/player/PlayerFilters.cpp:54
-msgid "Deny:"
+#: ui/preferences/Preferences.cpp:500
+msgid "set the minimun length in minutes to save track position"
 msgstr ""
 
-#: ui/splash/SplashWin.cpp:77
-msgid "Please Donate!"
+#: ui/preferences/Preferences.cpp:504
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:147
+msgid "minutes"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:510
+msgid "Load default layout"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:516
+msgid " Behaviour "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:518
+msgid "Activate task bar icon"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:529
+msgid "Integrate into SoundMenu"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:535
+msgid "Enqueue as default action"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:539
+msgid "Drop files clear playlist"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:543
+msgid "Instant text search"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:547
+msgid "When searching, pressing enter queues the result"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:552
+msgid "Show CD cover frame in player"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:558
+msgid " On Close "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:560
+msgid "Save playlist on close"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:564
+msgid "Close to task bar icon"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:569
+msgid "Ask confirmation on exit"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:612
+msgid " Collections "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:659
+msgid " Paths "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:679
+msgid " Words to detect covers "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:707 ui/preferences/Preferences.cpp:2282
+msgid " Options "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:709
+msgid "Update when opened "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:713
+msgid "Create playlists on scan"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:718
+msgid "Follow symbolic links on scan"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:722
+msgid "Scan embedded covers in audio files"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:727
+msgid "Embed rating, play count and labels"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:733
+msgid "Default copy action"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:738 ui/preferences/Preferences.cpp:1766
+#: ui/preferences/Preferences.cpp:1861 ui/preferences/Preferences.cpp:1884
+#: ui/player/PlayerFilters.cpp:124 info/smartmode/SmartMode.cpp:450
+msgid "None"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:814
+msgid "Play random"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:818 ui/MainFrame.cpp:3330
+#: ui/mediaviewer/MediaViewer.cpp:1379 ui/mediaviewer/MediaViewer.cpp:1398
+#: ui/mediaviewer/MediaViewer.cpp:1413
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:330
+msgid "track"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:818
+msgid "album"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:826
+msgid "when playlist is empty"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:832
+msgid "Delete played tracks from playlist"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:836
+msgid "Show notifications"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:840
+msgid "Enable equalizer"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:844
+msgid "Enable volume and fader"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:850
+msgid "ReplayGain mode:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:854
+msgid "Disabled"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:854 ui/player/PlayList.cpp:1636
+msgid "Track"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:854 ui/player/PlayList.cpp:1648
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:363
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:52
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:132
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:70
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/SoListBox.cpp:64
+#: ui/mediaviewer/library/SoListBox.cpp:664
+msgid "Album"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:861
+msgid "PreAmp:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:880
+msgid " Random / Smart play modes "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:890
+msgid "Tracks left to start search"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:898
+msgid "Tracks added each time"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:907
+msgid "Max played tracks kept in playlist"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:915
+msgid "Don't repeat last"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:923
+msgid "artists or"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:931 ui/MainFrame.cpp:3330
+#: ui/mediaviewer/MediaViewer.cpp:1379 ui/mediaviewer/MediaViewer.cpp:1398
+#: ui/mediaviewer/MediaViewer.cpp:1413
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:330
+msgid "tracks"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:939
+msgid " Silence detector "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:944
+msgid "Skip at"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:963
+msgid "In the last"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:973 ui/preferences/Preferences.cpp:1207
+msgid "seconds"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:981
+msgid " Output device "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:984
+msgid "Automatic"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:985
+msgid "GConf Defined"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1035
+msgid " Crossfader "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1042
+msgid "Fade-out length:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1051
+msgid "Select the length of the fade out. 0 for gapless playback"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1054
+msgid "Fade-in length:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1063
+msgid "Select the length of the fade in"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1066
+msgid "Fade-in volume:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1075
+msgid "Select the initial volume of the fade in"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1078
+msgid "Fade-in start:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1087
+msgid "Select at which volume of the fade out the fade in starts"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1131
+msgid " Record "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1133
+msgid "Enable recording"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1139
+msgid "Save to:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1143
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:125
+msgid "Select a folder"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1150
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:690
+msgid " Properties "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1157 ui/preferences/Preferences.cpp:2303
+msgid "Format:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1169
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:813
+msgid "Quality:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1174 copyto/Transcode.cpp:324
+msgid "Very High"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1175 copyto/Transcode.cpp:325
+msgid "High"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1176 copyto/Transcode.cpp:328
+msgid "Normal"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1177 copyto/Transcode.cpp:329
+msgid "Low"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1178 copyto/Transcode.cpp:330
+msgid "Very Low"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1190
+msgid "Split tracks"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1197
+msgid "Delete tracks shorter than"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1240
+msgid " Last.fm audioscrobble "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1242 ui/preferences/Preferences.cpp:1278
+msgid "Enabled"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1250 ui/preferences/Preferences.cpp:1286
+#: ui/preferences/Preferences.cpp:1548
+msgid "Username:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1258 ui/preferences/Preferences.cpp:1294
+#: ui/preferences/Preferences.cpp:1557
+msgid "Password:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1276
+msgid " Libre.fm audioscrobble "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1340
+msgid " Sources "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1385
+msgid " Targets "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1427
+msgid " Disabled Genres "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1449
+msgid " Font "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1451
+msgid "Font:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1463
+msgid "Align:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1468 misc/Accelerators.cpp:351
+msgid "Left"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1469
+msgid "Center"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1470 misc/Accelerators.cpp:357
+msgid "Right"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1515
+msgid " Proxy "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1517
+msgid "Proxy Enabled"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1526
+msgid "Hostname:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1537
+msgid "Port:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1571
+msgid " Filters "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1589
+msgid " Language "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1606
+msgid " Browser command "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1614
+msgid " Minimum radio allowed bit rate "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1621
+msgid " Player online buffer size "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1658
+msgid " Podcasts "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1662
+msgid "Destination directory:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1666
+msgid "Select podcasts folder"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1674
+msgid "Check every"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1679
+msgid "Hour"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1679
+msgid "Day"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1679
+msgid "Week"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1679
+msgid "Month"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1690
+msgid "Delete after"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1699
+msgid "Days"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1699
+msgid "Weeks"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1699
+msgid "Months"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1708
+msgid "Only if played"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1769 ui/preferences/Preferences.cpp:1864
+msgid "Invert"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1783
+msgid "Audio format:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1794
+msgid "Torrent command:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1878
+msgid "Membership :"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1885
+msgid "Streaming"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1886
+msgid "Downloading"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1899
+msgid "Username :"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1907
+msgid "Password :"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1925
+msgid "Stream as :"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1939
+msgid "Download as :"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1943
+msgid "Download Page"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:1984
+msgid " Links "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2038
+msgid "URL:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2063
+msgid " Define URLs using "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2069
+msgid ""
+"2 letters language code\n"
+"Text to search"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2106
+msgid " Commands "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2158
+msgid "Command:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2183
+msgid " Define commands using "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2189
+msgid ""
+"Album path\n"
+"Album cover file path\n"
+"Track path"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2226
+msgid " Patterns "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2296 ui/filebrowser/FileRenamer.cpp:77
+msgid "Pattern:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2321
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:706
+msgid "Path:"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2337
+msgid "Remove source files"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2354
+msgid " Define patterns using "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2360
+msgid ""
+"Artist\n"
+"Album Artist\n"
+"{aa} or {a}\n"
+"Album"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2368
+msgid ""
+"Composer\n"
+"Disk\n"
+"Filename\n"
+"Genre"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2376
+msgid ""
+"Index\n"
+"Number\n"
+"Title\n"
+"Year"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2431
+msgid " Accelerators "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2436
+msgid "Action"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2440
+msgid "Key"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2877 ui/preferences/Preferences.cpp:2897
+msgid "Collection: "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:2877 ui/preferences/Preferences.cpp:2897
+msgid "Enter the collection name"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3008
+msgid "Change library path"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3030 ui/mediaviewer/MediaViewer.cpp:1157
+msgid "Select library path"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3086 ui/preferences/Preferences.cpp:3106
+msgid "Word: "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3086 ui/preferences/Preferences.cpp:3106
+msgid "Enter the text to find covers"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3428
+msgid "Genre: "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3428
+msgid "Enter the genre to disable"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3632 ui/preferences/Preferences.cpp:3662
+msgid "Filter: "
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3632
+msgid "Enter the text to filter"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:3662
+msgid "Edit the text to filter"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:4204
+msgid "Select path"
+msgstr ""
+
+#: ui/preferences/Preferences.cpp:4402
+msgid "Key used by '"
+msgstr ""
+
+#: ui/confirmexit/ConfirmExit.cpp:29
+msgid "Please confirm"
+msgstr ""
+
+#: ui/confirmexit/ConfirmExit.cpp:42
+msgid "Are you sure you want to exit the application?"
+msgstr ""
+
+#: ui/confirmexit/ConfirmExit.cpp:48
+msgid "Don't ask again"
 msgstr ""
 
 #: ui/MainFrame.cpp:92
@@ -4256,6 +2412,11 @@ msgstr ""
 
 #: ui/MainFrame.cpp:240
 msgid "Welcome to Guayadeque "
+msgstr ""
+
+#: ui/MainFrame.cpp:255 ui/MainFrame.cpp:354
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:57
+msgid "Filters"
 msgstr ""
 
 #: ui/MainFrame.cpp:352 ui/MainFrame.cpp:1417 ui/MainFrame.cpp:4345
@@ -4470,8 +2631,16 @@ msgstr ""
 msgid "Stop after current playing or selected track"
 msgstr ""
 
+#: ui/MainFrame.cpp:1542 ui/player/PlayList.cpp:1601 misc/Accelerators.cpp:113
+msgid "Clear Playlist"
+msgstr ""
+
 #: ui/MainFrame.cpp:1543
 msgid "Clear the now playing playlist"
+msgstr ""
+
+#: ui/MainFrame.cpp:1581 ui/mediaviewer/library/SoListBox.cpp:615
+msgid "Set Rating"
 msgstr ""
 
 #: ui/MainFrame.cpp:1581
@@ -4621,16 +2790,1838 @@ msgstr ""
 msgid "Copy the selected tracks to a folder or device"
 msgstr ""
 
-#: ui/jamendo/Jamendo.cpp:1121 ui/jamendo/Jamendo.cpp:1131
-msgid "Download Albums torrents"
+#: ui/filebrowser/FileRenamer.cpp:50 ui/filebrowser/FileBrowser.cpp:1202
+msgid "Rename Files"
 msgstr ""
 
-#: MainApp.cpp:340
-msgid "Another program instance is already running."
+#: ui/filebrowser/FileRenamer.cpp:58
+msgid " Names Preview "
 msgstr ""
 
-#: MainApp.cpp:340
-msgid "Do you want to continue with the program?"
+#: ui/filebrowser/FileRenamer.cpp:85
+msgid ""
+"Pattern flags:\n"
+"{g} : Genre\n"
+"{a} : Artist\n"
+"{aa}: Album Artist\n"
+"{A} : {aa} or {a}\n"
+"{b} : Album\n"
+"{t} : Title\n"
+"{n} : Number\n"
+"{y} : Year\n"
+"{d} : Disk"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:231 ui/filebrowser/FileBrowser.cpp:600
+msgid "See used locations"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:232 ui/filebrowser/FileBrowser.cpp:601
+msgid "See system files"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:329 ui/filebrowser/FileBrowser.cpp:1108
+#: ui/player/PlayList.cpp:1502 ui/mediaviewer/treeview/TreePanel.cpp:343
+#: ui/mediaviewer/library/AlListBox.cpp:249
+#: ui/mediaviewer/library/ArListBox.cpp:134
+#: ui/mediaviewer/library/AAListBox.cpp:131
+#: ui/mediaviewer/library/SoListBox.cpp:462
+msgid "Add commands in preferences"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:345
+msgid "Play the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:351
+msgid "Add the selected folder to playlist"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:380 ui/filebrowser/FileBrowser.cpp:1165
+#: misc/Accelerators.cpp:117
+msgid "Edit Tracks"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:381
+msgid "Edit the tracks in the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:389
+msgid "Add the tracks in the selected folder to a playlist"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:396 ui/filebrowser/FileBrowser.cpp:1181
+msgid "Copy"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:397 ui/filebrowser/FileBrowser.cpp:1181
+msgid "Copy the selected folder to clipboard"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:403 ui/filebrowser/FileBrowser.cpp:1185
+#: ui/lyrics/LyricsPanel.cpp:301
+msgid "Paste"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:404
+msgid "Paste to the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:421
+msgid "Update the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:428 ui/filebrowser/FileBrowser.cpp:485
+#: ui/filebrowser/FileBrowser.cpp:489
+msgid "New Folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:428
+msgid "Create a new folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:431
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:294
+#: ui/mediaviewer/library/TaListBox.cpp:114
+msgid "Rename"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:431
+msgid "Rename the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:435 ui/filebrowser/FileBrowser.cpp:1206
+msgid "Remove"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:435
+msgid "Remove the selected folder"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:566
+msgid "Are you sure to delete the selected path ?"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:577
+msgid "Error deleting the folder "
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:776
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:66
+msgid "Size"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:777
+msgid "Modified"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1124
+msgid "Play current selected files"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1130
+msgid "Add current selected files to playlist"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1166
+msgid "Edit the current selected files"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1174
+msgid "Add the current selected tracks to a playlist"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1185
+msgid "Paste to the selected dir"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1202
+msgid "Rename the current selected file"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1206
+msgid "Delete the selected files"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1548 ui/filebrowser/FileBrowser.cpp:1564
+msgid "Directories"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:1969 ui/filebrowser/FileBrowser.cpp:2113
+#: ui/player/PlayList.cpp:1975 ui/mediaviewer/playlists/PlayListPanel.cpp:1447
+#: ui/mediaviewer/treeview/TreePanel.cpp:1147
+#: ui/mediaviewer/treeview/TreePanel.cpp:1417
+#: ui/mediaviewer/library/LibPanel.cpp:1440
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2513
+msgid "UnNamed"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:2216
+msgid "Are you sure to delete the selected files ?"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:2234
+msgid "There was an error deleting "
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:2235
+msgid ""
+"\n"
+"Continue deleting?"
+msgstr ""
+
+#: ui/filebrowser/FileBrowser.cpp:2236
+msgid "Continue"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:85
+msgid "Search the lyrics for the current playing track"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:91
+msgid "Configure lyrics preferences"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:95 ui/trackedit/TrackEdit.cpp:402
+msgid "Search for lyrics"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:100
+msgid "Edit the lyrics"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:106
+msgid "Save the lyrics"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:111
+msgid "Search the lyrics on the web"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:289
+msgid "Copy the content of the lyric to clipboard"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:301
+msgid "Paste the content of the lyric from clipboard"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:310 misc/Accelerators.cpp:410
+msgid "Print"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:310
+msgid "Print the content of the lyrics"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:445 ui/lyrics/LyricsPanel.cpp:564
+#: ui/lyrics/LyricsPanel.cpp:846 ui/lyrics/LyricsPanel.cpp:848
+msgid "Searching..."
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:760 ui/lyrics/LyricsPanel.cpp:852
+msgid "No lyrics found"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:844
+msgid "Lyrics from "
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2090
+msgid "Lyrics Target Editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2090
+msgid "Lyrics Source Editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2123
+msgid "Type:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2128
+msgid "Embedded"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2129
+msgid "File"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2130
+msgid "Command"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2139
+msgid "Source:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2147 ui/lyrics/LyricsPanel.cpp:2572
+msgid "Replace:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2181
+msgid "Extract:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2211
+msgid "Exclude:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2241
+msgid "Not Found:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2570
+msgid "Replace option editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2576
+msgid "Extract option editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2577 ui/lyrics/LyricsPanel.cpp:2583
+msgid "Begin:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2578 ui/lyrics/LyricsPanel.cpp:2584
+msgid "End:"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2582
+msgid "Exclude option editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2588
+msgid "Not Found option editor"
+msgstr ""
+
+#: ui/lyrics/LyricsPanel.cpp:2589 ui/lyrics/LyricsPanel.cpp:2590
+msgid "Tag:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:103
+msgid "Songs Editor"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:116
+msgid " Songs "
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:124
+msgid "Move the track to the previous position"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:130
+msgid "Move the track to the next position"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:159
+msgid "Copy the artist name to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:171
+msgid "Copy the album artist name to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:174 ui/trackedit/TrackEdit.cpp:498
+msgid "A. Artist:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:175
+msgid "shows the album artist of the track"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:183
+msgid "Copy the album name to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:194
+msgid "Copy the title to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:205
+msgid "Copy the composer to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:209
+msgid "Composer:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:217
+msgid "Copy the comment to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:221
+msgid "Comment:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:230
+msgid "Copy the number to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:233 ui/trackedit/TrackEdit.cpp:554
+msgid "Number:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:247
+msgid "Enumerate the tracks in the order they were added for editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:253
+msgid "Copy the disk to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:257
+msgid "Disk:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:267
+msgid "Copy the genre name to all songs you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:270
+msgid "Genre:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:278
+msgid "Copy the year to all songs you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:281 ui/trackedit/TrackEdit.cpp:520
+msgid "Year:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:297
+msgid "Rating:"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:346
+msgid "Add a picture from file to the current track"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:350
+msgid "Delete the picture from the current track"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:354
+msgid "Save the current picture to file"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:358
+msgid "Search the album cover"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:367
+msgid "Copy the current picture to all the tracks you are editing"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:375
+msgid "Pictures"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:433
+msgid "Type the artist name to search in musicbrainz"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:441
+msgid "Type the album name to search in musicbrainz"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:445
+msgid "Clear the search fields so it search using the music fingerprint"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:459
+msgid "Select the album found in musicbrainz"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:465
+msgid "Search albums in musicbrainz"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:471
+msgid "Copy the content of the album to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:495
+msgid "Copy the artist to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:506
+msgid "Copy the album artist to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:517
+msgid "Copy the album to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:528
+msgid "Copy the date to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:539
+msgid "Copy the song names to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:564
+msgid "Copy the number to the edited tracks"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:925
+#, c-format
+msgid ""
+"File Type\t: %s\n"
+"Length\t: %s"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:929
+#, c-format
+msgid ""
+"BitRate\t: %u Kbps\n"
+"File Size\t: %s"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:1657
+#, c-format
+msgid "Error: The album have %lu tracks and you are editing %lu"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:1663
+msgid "Warning: The length of some edited tracks don't match"
+msgstr ""
+
+#: ui/trackedit/TrackEdit.cpp:1667
+msgid "Everything ok"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1516
+msgid "Empty Playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1516
+msgid "The playlist is empty"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1525 ui/mediaviewer/treeview/TreePanel.cpp:431
+#: ui/mediaviewer/library/AlListBox.cpp:302
+#: ui/mediaviewer/library/ArListBox.cpp:193
+#: ui/mediaviewer/library/SoListBox.cpp:566
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:373
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1967
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2102 misc/Accelerators.cpp:116
+msgid "Edit Labels"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1526
+msgid "Edit the current selected tracks labels"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1531 ui/mediaviewer/treeview/TreePanel.cpp:441
+#: ui/mediaviewer/library/PcListBox.cpp:158
+#: ui/mediaviewer/library/RaListBox.cpp:190
+#: ui/mediaviewer/library/AlListBox.cpp:310
+#: ui/mediaviewer/library/ArListBox.cpp:201
+#: ui/mediaviewer/library/YeListBox.cpp:151
+#: ui/mediaviewer/library/AAListBox.cpp:192
+#: ui/mediaviewer/library/SoListBox.cpp:574
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:379
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1973
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2108
+msgid "Edit Songs"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1532
+msgid "Edit the current selected songs"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1541
+msgid "Set as Next Track"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1542
+msgid "Move the selected tracks to be played next"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1560
+msgid "Set the current selected tracks rating"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1566 misc/Accelerators.cpp:145
+msgid "Search"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1567
+msgid "Search a track in the playlist by name"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1589 ui/mediaviewer/library/SoListBox.cpp:628
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2121
+msgid "Create Smart Playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1589 ui/mediaviewer/library/SoListBox.cpp:628
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2121
+msgid "Create a smart playlist from this track"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1591 ui/mediaviewer/library/SoListBox.cpp:630
+msgid "Create Best Of Playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1591 ui/mediaviewer/library/AlListBox.cpp:345
+#: ui/mediaviewer/library/AAListBox.cpp:208
+#: ui/mediaviewer/library/SoListBox.cpp:630
+msgid "Create a playlist with the best of this artist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1596 ui/mediaviewer/playlists/PLSoListBox.cpp:164
+#: misc/Accelerators.cpp:133
+msgid "Randomize Playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1597 ui/mediaviewer/playlists/PLSoListBox.cpp:165
+msgid "Randomize the songs in the playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1602
+msgid "Remove all tracks from playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1609 ui/mediaviewer/playlists/PLSoListBox.cpp:172
+msgid "Remove from Playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1610
+msgid "Remove the selected tracks from playlist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1617 ui/mediaviewer/library/SoListBox.cpp:638
+msgid "Remove from Library"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1618
+msgid "Remove the selected tracks from library"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1623 ui/mediaviewer/library/SoListBox.cpp:643
+msgid "Delete from Drive"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1624
+msgid "Remove the selected tracks from drive"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1636
+msgid "Selects the current selected track in the library"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1639 ui/mediaviewer/audiocd/AudioCdPanel.cpp:361
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:50
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:130
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:67
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/SoListBox.cpp:62
+#: ui/mediaviewer/library/SoListBox.cpp:655
+msgid "Artist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1639 ui/mediaviewer/library/SoListBox.cpp:655
+msgid "Selects the artist of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1642 ui/mediaviewer/audiocd/AudioCdPanel.cpp:362
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:51
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:131
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:69
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/LibPanel.cpp:364
+#: ui/mediaviewer/library/LibPanel.cpp:371
+#: ui/mediaviewer/library/SoListBox.cpp:63
+#: ui/mediaviewer/library/SoListBox.cpp:658
+msgid "Album Artist"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1642
+msgid "Select the album artist of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1645 ui/mediaviewer/audiocd/AudioCdPanel.cpp:365
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:55
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:135
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:68
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/SoListBox.cpp:66
+#: ui/mediaviewer/library/SoListBox.cpp:661
+msgid "Composer"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1645
+msgid "Select the composer of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1648 ui/mediaviewer/library/SoListBox.cpp:664
+msgid "Select the album of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1651 ui/mediaviewer/audiocd/AudioCdPanel.cpp:368
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:58
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:136
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:71
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+#: ui/mediaviewer/library/AlListBox.cpp:322
+#: ui/mediaviewer/library/SoListBox.cpp:69
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:428
+msgid "Year"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1651
+msgid "Select the year of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1654
+msgid "Select the genre of the current song"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1657 ui/mediaviewer/library/SoListBox.cpp:667
+#: misc/Accelerators.cpp:409
+msgid "Select"
+msgstr ""
+
+#: ui/player/PlayList.cpp:1657 ui/mediaviewer/library/SoListBox.cpp:667
+msgid "Search in the library"
+msgstr ""
+
+#: ui/player/PlayList.cpp:2015
+msgid "Can't create a playlist without mediaviewer."
+msgstr ""
+
+#: ui/player/PlayList.cpp:2138 ui/mediaviewer/playlists/PlayListPanel.cpp:1340
+#: ui/mediaviewer/treeview/TreePanel.cpp:1312
+#: ui/mediaviewer/library/LibPanel.cpp:1367
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2186
+msgid "Tracks Labels Editor"
+msgstr ""
+
+#: ui/player/PlayList.cpp:2168
+msgid "Search: "
+msgstr ""
+
+#: ui/player/PlayList.cpp:2168
+msgid "Please enter the search term"
+msgstr ""
+
+#: ui/player/PlayList.cpp:2743
+msgid "Loading tracks. Please wait"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:176
+msgid "Go to the playlist previous track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:181
+msgid "Play or pause the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:186
+msgid "Go to the playlist next track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:190
+msgid "Stops the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:194
+msgid "Record to file"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:207
+msgid "Randomize the tracks in playlist"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:213 ui/player/PlayerPanel.cpp:3282
+msgid "Enable crossfading"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:213 ui/player/PlayerPanel.cpp:3282
+msgid "Disable crossfading"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:223
+msgid "Show the equalizer (right click for on/off)"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:227 ui/player/PlayerPanel.cpp:2949
+msgid "Volume"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:256
+msgid "Show the name of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:265
+msgid "Show the album name of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:276
+msgid "Show the artist name of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:286
+msgid "Show the year of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:289
+msgid "00:00 of 00:00"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:290
+msgid "Show the current position and song length of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:309
+msgid "Show the file format of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:316
+msgid "Show the bit rate of the current track"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:1401
+msgid "Buffering..."
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:2686
+msgid "Smart mode enabled"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:2692
+msgid "Repeat all"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:2697
+msgid "Repeat one"
+msgstr ""
+
+#: ui/player/PlayerPanel.cpp:2704
+msgid "Smart mode disabled"
+msgstr ""
+
+#: ui/player/PlayerFilters.cpp:45
+msgid "Allow:"
+msgstr ""
+
+#: ui/player/PlayerFilters.cpp:54
+msgid "Deny:"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:366
+msgid "Disk"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:616
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:285
+#: ui/mediaviewer/treeview/TreePanel.cpp:372
+#: ui/mediaviewer/library/SoListBox.cpp:492
+msgid "Edit"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:619
+#: ui/mediaviewer/library/SoListBox.cpp:495
+msgid "Edit the clicked column for the selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:625
+#: ui/mediaviewer/library/SoListBox.cpp:501
+msgid "Set"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:627
+#: ui/mediaviewer/library/SoListBox.cpp:503
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2563
+msgid "to"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:632
+#: ui/mediaviewer/library/SoListBox.cpp:508
+msgid "Set the clicked column for the selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:647
+#: ui/mediaviewer/library/PcListBox.cpp:114
+msgid "Play current selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:682
+msgid "Search again"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:683
+msgid "Search again for cd metadata"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:697
+msgid "Copy the current selected tracks to a directory or device"
+msgstr ""
+
+#: ui/mediaviewer/audiocd/AudioCdPanel.cpp:1090
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1614
+#: ui/mediaviewer/treeview/TreePanel.cpp:1584
+#: ui/mediaviewer/library/LibPanel.cpp:1648
+msgid "Field Editor"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:476
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1187
+msgid "embedded"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:684
+msgid "Portable Media Properties"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:715
+msgid "Used:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:726
+#, c-format
+msgid "%s free of %s"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:747
+msgid "Name Pattern:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:752
+msgid ""
+"{a}\t: Artist\t\t\t{aa} : Album Artist\n"
+"{b}\t: Album\t\t\t{d}\t : Disk\n"
+"{f}\t: Filename\t\t{g}\t : Genre\n"
+"{n}\t: Number\t\t\t{t}\t : Title\n"
+"{y}\t: Year"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:757
+msgid "Audio Folders:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:768
+msgid "Audio Formats:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:779
+msgid "Transcode to:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:800
+msgid "Unsupported formats only"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:800
+msgid "always"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:831
+msgid "Audio"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:843
+msgid "Playlist Folders:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:853
+msgid "Playlist Format:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:877
+msgid "Cover Format:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:890
+msgid "Cover Name:"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:901
+msgid "Covers Size (pixels):"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:911
+msgid "Covers"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1022
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1116
+msgid "Select audio folder"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1090
+msgid "Audio format"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1164
+msgid "Playlist format"
+msgstr ""
+
+#: ui/mediaviewer/portablemedia/PortableMedia.cpp:1215
+msgid "Cover format"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:86
+msgid "Static playlists"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:87
+msgid "Dynamic playlists"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:233
+#: ui/mediaviewer/treeview/TreePanel.cpp:395
+#: ui/mediaviewer/library/SoListBox.cpp:531
+msgid "Add current selected songs to the playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:263
+msgid "New Dynamic Playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:263
+msgid "Create a new dynamic playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:269
+msgid "Import a playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:275
+msgid "Export the playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:285
+msgid "Edit the selected playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:289
+msgid "Save the selected playlist as a Static Playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:294
+msgid "Change the name of the selected playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:299
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:309
+msgid "Delete the selected playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:305
+msgid "Set as Allow Filter"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:305
+msgid "Set this playlist as the allow filter"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:309
+msgid "Set as Deny Filter"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1032
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1169
+msgid "Playlist Name: "
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1033
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1170
+msgid "Enter the new playlist name"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1072
+msgid "Are you sure to delete the selected Playlist?"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1153
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1226
+msgid "Select the playlist file"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListPanel.cpp:1181
+msgid "New Playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PLSoListBox.cpp:172
+msgid "Delete the current selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:54
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:134
+msgid "Label"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:56
+msgid "Comment"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:57
+#: ui/mediaviewer/library/SoListBox.cpp:76
+msgid "Path"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:64
+msgid "Track Number"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:65
+#: ui/mediaviewer/library/SoListBox.cpp:70
+msgid "Bit Rate"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:67
+#: ui/mediaviewer/library/SoListBox.cpp:67
+msgid "Disc"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:68
+msgid "Has Cover"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:73
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:83
+msgid "contains"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:74
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:84
+msgid "does not contain"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:75
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:85
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:94
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:102
+msgid "is"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:76
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:86
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:95
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:103
+msgid "is not"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:77
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:87
+msgid "begins with"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:78
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:88
+msgid "ends with"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:89
+msgid "not set"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:96
+msgid "at least"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:97
+msgid "at most"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:104
+msgid "after"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:105
+msgid "before"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:110
+msgid "in the last"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:111
+msgid "before the last"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:116
+msgid "false"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:117
+msgid "true"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:121
+#: ui/mediaviewer/library/LibPanel.cpp:391
+#: ui/mediaviewer/library/LibPanel.cpp:537
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:303
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1725
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2556
+#: info/smartmode/SmartMode.cpp:467
+msgid "Tracks"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:122
+#: info/smartmode/SmartMode.cpp:468
+msgid "Minutes"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:142
+msgid "Random"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:148
+msgid "hours"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:149
+msgid "days"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:150
+msgid "weeks"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:151
+msgid "months"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:441
+msgid "Filter Album Browser"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:442
+msgid "Dynamic Playlist Editor"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:468
+msgid " Current Filters "
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:549
+msgid " Result "
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:554
+#: info/smartmode/SmartMode.cpp:456
+msgid "Limit to"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:574
+msgid "Any filter selects tracks"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:585
+msgid "Sort by"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:595
+msgid "Descending"
+msgstr ""
+
+#: ui/mediaviewer/playlists/DynamicPlayList.cpp:613
+msgid "Add tracks on any criteria"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:52
+msgid "Playlist:"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:63
+msgid "New playlist"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:67
+msgid "Where:"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:71
+msgid "Beginning"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:71 misc/Accelerators.cpp:378
+msgid "End"
+msgstr ""
+
+#: ui/mediaviewer/playlists/PlayListAppend.cpp:77
+msgid "Tracks:"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:232
+msgid "All Albums"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:241
+msgid "Library view"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:245
+msgid "Album Browser view"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:249
+msgid "Tree view"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:265
+msgid "View the current defined filters"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:270
+msgid "Add a new album browser filter"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:274
+msgid "Delete the current selected filter"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:279
+msgid "Edit the current selected filter"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:853
+#: ui/mediaviewer/treeview/TreePanel.cpp:1178
+msgid "New Filter"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:984
+msgid "Collection"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:1187
+msgid "This Path is already in the library"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:1188
+msgid "Adding path error"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:2172
+msgid " smart playlist"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:2181
+msgid "Playlist"
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:2215
+msgid "The best of "
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:2241
+#, c-format
+msgid "No tracks found for %s."
+msgstr ""
+
+#: ui/mediaviewer/MediaViewer.cpp:2246
+#, c-format
+msgid "Best tracks for '%s' not found."
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:75
+msgid "Genres,Artists,Albums"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:76
+msgid "Genres,Year,Artists,Albums"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:91
+msgid "Sortings"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:368
+#: ui/mediaviewer/library/TaListBox.cpp:107
+msgid "Create"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:368
+msgid "Create a new filter"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:372
+msgid "Edit the selected filter"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:376
+msgid "Delete the selected filter"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:432
+msgid "Edit the labels assigned to the selected items"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:442
+#: ui/mediaviewer/library/PcListBox.cpp:159
+#: ui/mediaviewer/library/RaListBox.cpp:191
+#: ui/mediaviewer/library/CoListBox.cpp:152
+#: ui/mediaviewer/library/YeListBox.cpp:152
+#: ui/mediaviewer/library/AAListBox.cpp:193
+msgid "Edit the selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:1049
+#: ui/mediaviewer/library/LibPanel.cpp:951
+msgid "Artist Labels Editor"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:1049
+#: ui/mediaviewer/library/LibPanel.cpp:1149
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1468
+msgid "Albums Labels Editor"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreePanel.cpp:1220
+msgid "Are you sure to delete the selected filter?"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:36
+msgid "Filter Editor"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:73
+msgid "Play Count"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:121
+msgid "Filter:"
+msgstr ""
+
+#: ui/mediaviewer/treeview/TreeViewFilterEditor.cpp:125
+msgid "PlayCount"
+msgstr ""
+
+#: ui/mediaviewer/library/PcListBox.cpp:121
+#: ui/mediaviewer/library/RaListBox.cpp:153
+#: ui/mediaviewer/library/CoListBox.cpp:114
+#: ui/mediaviewer/library/YeListBox.cpp:114
+#: ui/mediaviewer/library/AAListBox.cpp:155
+msgid "Add current selected tracks to playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:107
+msgid "Create a new label"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:114
+msgid "Change selected label"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:118
+msgid "Delete selected labels"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:127
+msgid "Play current selected labels"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:134
+msgid "Add current selected labels to playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/TaListBox.cpp:230
+msgid "Enter the new label name"
+msgstr ""
+
+#: ui/mediaviewer/library/GeListBox.cpp:96
+msgid "Play current selected genres"
+msgstr ""
+
+#: ui/mediaviewer/library/GeListBox.cpp:103
+msgid "Add current selected genres to playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/RaListBox.cpp:146
+msgid "Play the selected tracks"
+msgstr ""
+
+#: ui/mediaviewer/library/CoListBox.cpp:107
+msgid "Play current selected composer"
+msgstr ""
+
+#: ui/mediaviewer/library/CoListBox.cpp:123
+#: ui/mediaviewer/library/CoListBox.cpp:130
+#: ui/mediaviewer/library/CoListBox.cpp:137
+#: ui/mediaviewer/library/AlListBox.cpp:281
+#: ui/mediaviewer/library/AlListBox.cpp:287
+#: ui/mediaviewer/library/AlListBox.cpp:293
+msgid "Add current selected albums to the Playlist as Next Tracks"
+msgstr ""
+
+#: ui/mediaviewer/library/CoListBox.cpp:142
+#: ui/mediaviewer/library/AlListBox.cpp:297
+msgid "Add the selected albums after"
+msgstr ""
+
+#: ui/mediaviewer/library/CoListBox.cpp:151
+msgid "Edit songs"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:181
+msgid "by "
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:267
+msgid "Play current selected albums"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:273
+msgid "Add current selected albums to the Playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:303
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:373
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1967
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2102
+msgid "Edit the labels assigned to the selected albums"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:311
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:379
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1973
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2108
+msgid "Edit the selected songs"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:321
+msgid "Albums are sorted by name"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:322
+msgid "Albums are sorted by year"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:323
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:432
+msgid "Year Descending"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:323
+msgid "Albums are sorted by year descending"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:324
+msgid "Artist, Name"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:324
+msgid "Albums are sorted by artist and album name"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:325
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:440
+msgid "Artist, Year"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:325
+msgid "Albums are sorted by artist and year"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:326
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:444
+msgid "Artist, Year Descending"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:326
+msgid "Albums are sorted by artist and year descending"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:331
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:452
+msgid "Sort By"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:331
+msgid "Sets the albums order"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:339
+#: ui/mediaviewer/library/YeListBox.cpp:161
+#: ui/mediaviewer/library/AAListBox.cpp:202
+msgid "Save the selected tracks to Playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:344
+#: ui/mediaviewer/library/ArListBox.cpp:216
+#: ui/mediaviewer/library/AAListBox.cpp:207
+msgid "Create Best of Playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:352
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:398
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1992
+msgid "Download Cover"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:352
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:398
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1992
+msgid "Download cover for the current selected album"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:356
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:402
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1996
+msgid "Select Cover"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:356
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:402
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1996
+msgid "Select the cover image file from disk"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:360
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:406
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2000
+msgid "Delete Cover"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:360
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:406
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2000
+msgid "Delete the cover for the selected album"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:367
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:413
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2007
+msgid "Embed Cover"
+msgstr ""
+
+#: ui/mediaviewer/library/AlListBox.cpp:367
+msgid "Embed the current cover to the album files"
+msgstr ""
+
+#: ui/mediaviewer/library/ArListBox.cpp:151
+#: ui/mediaviewer/library/YeListBox.cpp:107
+msgid "Play current selected artists"
+msgstr ""
+
+#: ui/mediaviewer/library/ArListBox.cpp:158
+msgid "Add current selected artists to playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/ArListBox.cpp:194
+msgid "Edit the labels assigned to the selected artists"
+msgstr ""
+
+#: ui/mediaviewer/library/ArListBox.cpp:202
+msgid "Edit the songs from the selected artists"
+msgstr ""
+
+#: ui/mediaviewer/library/ArListBox.cpp:217
+msgid "Create a playlist with the best of this aretist"
+msgstr ""
+
+#: ui/mediaviewer/library/LibPanel.cpp:1226
+msgid "Are you sure to delete the selected album cover?"
+msgstr ""
+
+#: ui/mediaviewer/library/LibPanel.cpp:2786
+msgid ""
+"Are you sure to delete the selected tracks from your drive?\n"
+"This will permanently erase the selected tracks."
+msgstr ""
+
+#: ui/mediaviewer/library/LibPanel.cpp:2787
+msgid "Remove tracks from drive"
+msgstr ""
+
+#: ui/mediaviewer/library/AAListBox.cpp:148
+msgid "Play current selected album artist"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:77
+msgid "Offset"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:567
+msgid "Edit the labels assigned to the selected songs"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:575
+msgid "Edit the songs selected"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:622
+msgid "Save all selected tracks as a playlist"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:638
+msgid "Remove the current selected tracks from library"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:643
+msgid "Remove the current selected tracks from drive"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:652
+msgid "Selects the genre of the current song"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:658
+msgid "Selects the album artist of the current song"
+msgstr ""
+
+#: ui/mediaviewer/library/SoListBox.cpp:661
+msgid "Selects the composer of the current song"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:413
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2007
+msgid "Embed the cover to the selected album tracks"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:424
+msgid "Sort albums by name"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:428
+msgid "Sort albums by year"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:432
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:448
+msgid "Sort albums by year descendant"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:436
+msgid "Artist Name"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:436
+msgid "Sort albums by artist name"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:440
+msgid "Sort albums by artist, year"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:444
+msgid "Sort albums by artist, year descendant"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:452
+msgid "Set the albums sorting"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:917 misc/Accelerators.cpp:306
+msgid "Back"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:1767
+msgid "Page"
+msgstr ""
+
+#: ui/mediaviewer/albumbrowser/AlbumBrowser.cpp:2564
+msgid "of"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:93
+msgid "Copy to Option:"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:121
+msgid "Destination Folder:"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:131
+msgid " Files "
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:243
+msgid "Select files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:244
+msgid "Audio files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:245
+msgid "mp3 files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:246
+msgid "ogg files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:247
+msgid "flac files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:248
+msgid "mp4 files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:249
+msgid "wma files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:250
+msgid "ape files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:251
+msgid "waf files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:252
+msgid "aif files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:253
+msgid "wv files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:254
+msgid "tta files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:255
+msgid "mpc files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:256
+msgid "other files"
+msgstr ""
+
+#: ui/mediaviewer/importfiles/ImportFiles.cpp:340
+msgid "No files added"
+msgstr ""
+
+#: onlinelinks/OnlineLinks.cpp:70
+msgid "Add search links in preferences"
+msgstr ""
+
+#: copyto/CopyTo.cpp:887
+#, c-format
+msgid ""
+"Copied %u files (%s)\n"
+"in %s seconds"
+msgstr ""
+
+#: copyto/CopyTo.cpp:892
+msgid "Finished copying files"
+msgstr ""
+
+#: copyto/Transcode.cpp:300
+msgid "Keep Format"
+msgstr ""
+
+#: copyto/Transcode.cpp:323
+msgid "Keep Quality"
+msgstr ""
+
+#: copyto/Transcode.cpp:326
+msgid "Very Good"
+msgstr ""
+
+#: copyto/Transcode.cpp:327
+msgid "Good"
 msgstr ""
 
 #: misc/Accelerators.cpp:111
@@ -4893,6 +4884,10 @@ msgstr ""
 msgid "GiBytes"
 msgstr ""
 
-#: onlinelinks/OnlineLinks.cpp:70
-msgid "Add search links in preferences"
+#: MainApp.cpp:340
+msgid "Another program instance is already running."
+msgstr ""
+
+#: MainApp.cpp:340
+msgid "Do you want to continue with the program?"
 msgstr ""

--- a/src/audio/FaderPlaybin.cpp
+++ b/src/audio/FaderPlaybin.cpp
@@ -1395,7 +1395,7 @@ bool guFaderPlaybin::AddRecordElement( GstPad * pad )
         return false;
     }
 
-    m_TeeSrcPad = gst_element_get_request_pad( m_Tee, "src_%u" );
+    m_TeeSrcPad = gst_element_request_pad_simple(m_Tee, "src_%u");
     guLogGstPadData( "guFaderPlaybin::AddRecordElement src request pad", m_TeeSrcPad );
     if( m_TeeSrcPad == NULL )
     {

--- a/src/db/DbLibrary.cpp
+++ b/src/db/DbLibrary.cpp
@@ -306,7 +306,7 @@ bool guTrack::ReadFromFile( const wxString &filename )
       if( m_SongName.IsEmpty() )
         m_SongName = m_FileName.AfterLast( wxT( '/' ) ).BeforeLast( wxT( '.' ) );
 
-      m_SongId = wxNOT_FOUND;;
+      m_SongId = wxNOT_FOUND;
 
       m_Rating   = wxNOT_FOUND;
 
@@ -3330,10 +3330,10 @@ void guDbLibrary::UpdateStaticPlayListFile( const int plid )
     if( !PlaylistPath.IsEmpty() )
     {
         wxFileName FileName( PlaylistPath );
-        if( FileName.Normalize() )
+        if( FileName.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS) )
         {
             guTrackArray Tracks;
-            GetPlayListSongs( plid, guPLAYLIST_TYPE_STATIC, &Tracks, NULL, NULL );
+            GetPlayListSongs( plid, guPLAYLIST_TYPE_STATIC, &Tracks, nullptr, nullptr );
             guPlaylistFile PlayListFile;
             PlayListFile.SetName( FileName.GetFullPath() );
             int Count = Tracks.Count();
@@ -4014,7 +4014,7 @@ int guDbLibrary::GetPlayListSongs( const int plid, const int pltype, guTrackArra
 
       while( dbRes.NextRow() )
       {
-        guTrack * Track = new guTrack();
+        auto * Track = new guTrack();
         FillTrackFromDb( Track, &dbRes );
         if( PlayList.m_Limited )
         {
@@ -4166,7 +4166,7 @@ void guDbLibrary::GetDynamicPlayList( const int plid, guDynPlayList * playlist )
     dbRes = ExecuteQuery( query );
     while( dbRes.NextRow() )
     {
-      guFilterItem * FilterItem = new guFilterItem();
+      auto * FilterItem = new guFilterItem();
       FilterItem->m_Type = dbRes.GetInt( 0 );
       FilterItem->m_Option = dbRes.GetInt( 1 );
       FilterItem->m_Text = dbRes.GetString( 2 );
@@ -6209,6 +6209,7 @@ bool guDbLibrary::AddCachedPlayedSong( const guCurrentTrack &Song )
 
   int PlayTime = Song.m_PlayTime / 1000;
   int TrackLength = Song.m_Length / 1000;
+
   if( Song.m_Type == guTRACK_TYPE_RADIOSTATION )
   {
       PlayTime = 180;

--- a/src/db/DbLibrary.h
+++ b/src/db/DbLibrary.h
@@ -87,7 +87,7 @@ class guTrack
 {
   public:
     guTrackType     m_Type;
-    int             m_SongId;
+    int             m_SongId = 0;
     wxString        m_SongName;
     int             m_AlbumId;
     wxString        m_AlbumName;
@@ -344,9 +344,9 @@ class guDbLibrary : public guDb
 
   public :
                         guDbLibrary();
-                        guDbLibrary( const wxString &DbName );
-                        guDbLibrary( guDb * db );
-                        ~guDbLibrary();
+                        explicit guDbLibrary( const wxString &DbName );
+                        explicit guDbLibrary( guDb * db );
+                        ~guDbLibrary() override;
 
     virtual int         GetDbVersion( void );
 

--- a/src/taginfo/TagInfo.h
+++ b/src/taginfo/TagInfo.h
@@ -79,15 +79,15 @@ class guTagInfo
 
   protected :
     bool            ReadExtendedTags( ID3v2::Tag * tag );
-    bool            WriteExtendedTags( ID3v2::Tag * tag, const int changedflag );
+    bool            WriteExtendedTags( ID3v2::Tag * tag, const int changedflag ) const;
     bool            ReadExtendedTags( Ogg::XiphComment * tag );
-    bool            WriteExtendedTags( Ogg::XiphComment * tag, const int changedflag );
+    bool            WriteExtendedTags( Ogg::XiphComment * tag, const int changedflag ) const;
     bool            ReadExtendedTags( MP4::Tag * tag );
-    bool            WriteExtendedTags( MP4::Tag * tag, const int changedflag );
+    bool            WriteExtendedTags( MP4::Tag * tag, const int changedflag ) const;
     bool            ReadExtendedTags( APE::Tag * tag );
-    bool            WriteExtendedTags( APE::Tag * tag, const int changedflag );
+    bool            WriteExtendedTags( APE::Tag * tag, const int changedflag ) const;
     bool            ReadExtendedTags( ASF::Tag * tag );
-    bool            WriteExtendedTags( ASF::Tag * tag, const int changedflag );
+    bool            WriteExtendedTags( ASF::Tag * tag, const int changedflag ) const;
 
   public:
     wxString        m_FileName;

--- a/src/ui/lyrics/LyricsPanel.cpp
+++ b/src/ui/lyrics/LyricsPanel.cpp
@@ -1799,7 +1799,7 @@ void guLyricSearchThread::LyricFile( guLyricSource &lyricsource )
 {
     wxString FilePath = GetSource( lyricsource );
     wxFileName FileName( FilePath );
-    if( FileName.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+    if( FileName.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
     {
         if( wxFileExists( FileName.GetFullPath() ) )
         {
@@ -1900,7 +1900,7 @@ void guLyricSearchThread::ProcessSave( guLyricSource &lyricsource )
                     }
 
                     wxFileName FileName( TargetFileName );
-                    if( FileName.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+                    if( FileName.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
                     {
                         FileName.Mkdir( 0770, wxPATH_MKDIR_FULL );
 

--- a/src/ui/magnatune/Magnatune.cpp
+++ b/src/ui/magnatune/Magnatune.cpp
@@ -440,7 +440,7 @@ guMagnatuneDownloadThread::ExitCode guMagnatuneDownloadThread::Entry()
     wxFileName CoverFile = wxFileName( guPATH_MAGNATUNE_COVERS +
                  wxString::Format( wxT( "%s-%s.jpg" ), m_ArtistName.c_str(), m_AlbumName.c_str() ) );
 
-    if( CoverFile.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+    if( CoverFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
     {
         wxString CoverUrl = wxString::Format( wxT( "http://he3.magnatune.com/music/%s/%s/cover_600.jpg" ),
                 guURLEncode( m_ArtistName, false ).c_str(),
@@ -1082,7 +1082,7 @@ wxImage * guMediaViewerMagnatune::GetAlbumCover( const int albumid, int &coverid
     wxFileName CoverFile = wxFileName( guPATH_MAGNATUNE_COVERS +
                  wxString::Format( wxT( "%s-%s.jpg" ), artistname.c_str(), albumname.c_str() ) );
 
-    if( CoverFile.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+    if( CoverFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
     {
         if( CoverFile.FileExists() )
         {

--- a/src/ui/mediaviewer/playlists/PlayListFile.cpp
+++ b/src/ui/mediaviewer/playlists/PlayListFile.cpp
@@ -231,7 +231,7 @@ bool guPlaylistFile::ReadPlsStream( wxInputStream &playlist, const wxString &pat
                             else
                             {
                                 wxFileName FileName( Location );
-                                FileName.Normalize( wxPATH_NORM_ALL, path );
+                                FileName.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS, path );
 
                                 m_Playlist.Add( new guPlaylistItem( FileName.GetFullPath(), Title ) );
                             }
@@ -307,7 +307,7 @@ bool guPlaylistFile::ReadM3uStream( wxInputStream &playlist, const wxString &pat
                 else
                 {
                     wxFileName FileName( Lines[ Index ] );
-                    FileName.Normalize( wxPATH_NORM_ALL, path );
+                    FileName.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS, path );
                     m_Playlist.Add( new guPlaylistItem( FileName.GetFullPath(), ItemName ) );
                 }
 

--- a/src/ui/mediaviewer/portablemedia/PortableMedia.cpp
+++ b/src/ui/mediaviewer/portablemedia/PortableMedia.cpp
@@ -553,7 +553,7 @@ void guPortableMediaLibrary::DeletePlayList( const int plid )
         }
 
         wxFileName FileName( PlayListFile );
-        if( FileName.Normalize() )
+        if( FileName.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS) )
         {
             if( FileName.FileExists() )
             {
@@ -601,7 +601,7 @@ void guPortableMediaLibrary::UpdateStaticPlayListFile( const int plid )
         }
 
         wxFileName FileName( PlayListFile );
-        if( FileName.Normalize() )
+        if( FileName.Normalize(wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS) )
         {
             guTrackArray Tracks;
             GetPlayListSongs( plid, guPLAYLIST_TYPE_STATIC, &Tracks, NULL, NULL );
@@ -696,7 +696,7 @@ guPortableMediaProperties::guPortableMediaProperties( wxWindow * parent, guPorta
 
 	NameLabel = new wxStaticText( this, wxID_ANY, _("Name:"), wxDefaultPosition, wxDefaultSize, 0 );
 	NameLabel->Wrap( -1 );
-	NameLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+    NameLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 	PMFlexSizer->Add( NameLabel, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT|wxTOP, 5 );
 
 	m_NameText = new wxStaticText( this, wxID_ANY, mediadevice->DeviceName(), wxDefaultPosition, wxDefaultSize, 0 );
@@ -705,7 +705,7 @@ guPortableMediaProperties::guPortableMediaProperties( wxWindow * parent, guPorta
 
 	MountPathLabel = new wxStaticText( this, wxID_ANY, _("Path:"), wxDefaultPosition, wxDefaultSize, 0 );
 	MountPathLabel->Wrap( -1 );
-	MountPathLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	MountPathLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 	PMFlexSizer->Add( MountPathLabel, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT, 5 );
 
 	m_MountPathText = new wxStaticText( this, wxID_ANY, mediadevice->MountPath(), wxDefaultPosition, wxDefaultSize, 0 );

--- a/src/ui/podcasts/ChannelEditor.cpp
+++ b/src/ui/podcasts/ChannelEditor.cpp
@@ -73,7 +73,7 @@ guChannelEditor::guChannelEditor( wxWindow * parent, guPodcastChannel * channel 
     wxFileName ImageFile = wxFileName( PodcastsPath + wxT( "/" ) +
                                        channel->m_Title + wxT( "/" ) +
                                        channel->m_Title + wxT( ".jpg" ) );
-    if( ImageFile.Normalize( wxPATH_NORM_ALL | wxPATH_NORM_CASE ) )
+    if( ImageFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
     {
         wxImage PodcastImage;
         if( wxFileExists( ImageFile.GetFullPath() ) &&
@@ -101,7 +101,7 @@ guChannelEditor::guChannelEditor( wxWindow * parent, guPodcastChannel * channel 
 
 	DescLabel = new wxStaticText( this, wxID_ANY, _( "Description:" ), wxDefaultPosition, wxDefaultSize, 0 );
 	DescLabel->Wrap( -1 );
-	DescLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DescLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	FlexGridSizer->Add( DescLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -113,7 +113,7 @@ guChannelEditor::guChannelEditor( wxWindow * parent, guPodcastChannel * channel 
 
 	AuthorLabel = new wxStaticText( this, wxID_ANY, _("Author:"), wxDefaultPosition, wxDefaultSize, 0 );
 	AuthorLabel->Wrap( -1 );
-	AuthorLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	AuthorLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	FlexGridSizer->Add( AuthorLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -123,7 +123,7 @@ guChannelEditor::guChannelEditor( wxWindow * parent, guPodcastChannel * channel 
 
 	OwnerLabel = new wxStaticText( this, wxID_ANY, _("Owner:"), wxDefaultPosition, wxDefaultSize, 0 );
 	OwnerLabel->Wrap( -1 );
-	OwnerLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	OwnerLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	FlexGridSizer->Add( OwnerLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 

--- a/src/ui/podcasts/Podcasts.cpp
+++ b/src/ui/podcasts/Podcasts.cpp
@@ -213,7 +213,7 @@ void guPodcastChannel::CheckLogo( void )
         wxFileName ImageFile = wxFileName( PodcastsPath + wxT( "/" ) +
                                            m_Title + wxT( "/" ) +
                                            m_Title + wxT( ".jpg" ) );
-        if( ImageFile.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+        if( ImageFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
         {
             if( !wxFileExists( ImageFile.GetFullPath() ) )
             {
@@ -489,7 +489,7 @@ void guPodcastChannel::CheckDir( void )
 
     // Create the channel dir
     wxFileName ChannelDir = wxFileName( PodcastsPath + wxT( "/" ) + m_Title );
-    if( ChannelDir.Normalize( wxPATH_NORM_ALL | wxPATH_NORM_CASE ) )
+    if( ChannelDir.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
     {
         if( !wxDirExists( ChannelDir.GetFullPath() ) )
         {
@@ -695,7 +695,7 @@ guPodcastDownloadQueueThread::ExitCode guPodcastDownloadQueueThread::Entry()
                                             PodcastItem->m_Channel + wxT( "/" ) +
                                             //PodcastTime.Format( wxT( "%Y%m%d%H%M%S-" ) ) +
                                             Uri.GetPath().AfterLast( wxT( '/' ) ) );
-                if( PodcastFile.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+                if( PodcastFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
                 {
                     PodcastItem->m_FileName = PodcastFile.GetFullPath();
 

--- a/src/ui/podcasts/PodcastsPanel.cpp
+++ b/src/ui/podcasts/PodcastsPanel.cpp
@@ -943,13 +943,13 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	m_DetailChannelTitle = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
 	m_DetailChannelTitle->Wrap( -1 );
-	m_DetailChannelTitle->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 92, false, wxEmptyString ) );
+	m_DetailChannelTitle->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( m_DetailChannelTitle, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 
 	DetailDescLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Description:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailDescLabel->Wrap( -1 );
-	DetailDescLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailDescLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailDescLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -959,7 +959,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailAuthorLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Author:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailAuthorLabel->Wrap( -1 );
-	DetailAuthorLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailAuthorLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailAuthorLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -969,7 +969,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailOwnerLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Owner:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailOwnerLabel->Wrap( -1 );
-	DetailOwnerLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailOwnerLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailOwnerLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -980,7 +980,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 	wxStaticText * DetailLinkLabel;
 	DetailLinkLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Link:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailLinkLabel->Wrap( -1 );
-	DetailLinkLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailLinkLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailLinkLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -995,7 +995,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailItemTitleLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Title:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailItemTitleLabel->Wrap( -1 );
-	DetailItemTitleLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailItemTitleLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailItemTitleLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -1005,7 +1005,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailItemSumaryLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Sumary:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailItemSumaryLabel->Wrap( -1 );
-	DetailItemSumaryLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailItemSumaryLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailItemSumaryLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -1015,7 +1015,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailItemDateLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Date:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailItemDateLabel->Wrap( -1 );
-	DetailItemDateLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailItemDateLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailItemDateLabel, 0, wxALIGN_RIGHT|wxBOTTOM|wxRIGHT|wxLEFT, 5 );
 
@@ -1025,7 +1025,7 @@ guPodcastPanel::guPodcastPanel( wxWindow * parent, guDbPodcasts * db, guMainFram
 
 	DetailItemLengthLabel = new wxStaticText( m_DetailScrolledWindow, wxID_ANY, _("Length:"), wxDefaultPosition, wxDefaultSize, 0 );
 	DetailItemLengthLabel->Wrap( -1 );
-	DetailItemLengthLabel->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
+	DetailItemLengthLabel->SetFont(wxFont(wxNORMAL_FONT->GetPointSize(), wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, wxEmptyString));
 
 	m_DetailFlexGridSizer->Add( DetailItemLengthLabel, 0, wxBOTTOM|wxRIGHT|wxLEFT|wxALIGN_RIGHT, 5 );
 
@@ -1212,7 +1212,7 @@ void guPodcastPanel::AddChannel( wxCommandEvent &event )
                 // Create the channel dir
                 wxFileName ChannelDir = wxFileName( m_PodcastsPath + wxT( "/" ) +
                                           PodcastChannel.m_Title );
-                if( ChannelDir.Normalize( wxPATH_NORM_ALL | wxPATH_NORM_CASE ) )
+                if( ChannelDir.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
                 {
                     if( !wxDirExists( ChannelDir.GetFullPath() ) )
                     {
@@ -1278,7 +1278,7 @@ void guPodcastPanel::ChannelProperties( wxCommandEvent &event )
         // Create the channel dir
         wxFileName ChannelDir = wxFileName( m_PodcastsPath + wxT( "/" ) +
                                   PodcastChannel.m_Title );
-        if( ChannelDir.Normalize( wxPATH_NORM_ALL | wxPATH_NORM_CASE ) )
+        if( ChannelDir.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
         {
             if( !wxDirExists( ChannelDir.GetFullPath() ) )
             {
@@ -1481,7 +1481,7 @@ void guPodcastPanel::UpdateChannelInfo( int itemid )
         wxFileName ImageFile = wxFileName( m_PodcastsPath + wxT( "/" ) +
                                            PodcastChannel.m_Title + wxT( "/" ) +
                                            PodcastChannel.m_Title + wxT( ".jpg" ) );
-        if( ImageFile.Normalize( wxPATH_NORM_ALL|wxPATH_NORM_CASE ) )
+        if( ImageFile.Normalize( wxPATH_NORM_DOTS | wxPATH_NORM_TILDE | wxPATH_NORM_CASE | wxPATH_NORM_ABSOLUTE | wxPATH_NORM_LONG | wxPATH_NORM_SHORTCUT | wxPATH_NORM_ENV_VARS ) )
         {
             wxImage PodcastImage;
             if( wxFileExists( ImageFile.GetFullPath() ) &&


### PR DESCRIPTION
This commit migrates the project from the deprecated taglibv1 library to the newer taglibv2 version. The following changes were made:

- Updated dependencies to use taglibv2 instead of taglibv1
- Refactored code to comply with the taglibv2 API changes
- Resolved all build warnings related to the library migration